### PR TITLE
feat: add client.sent property

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ The client is not closed when the `error` event is emitted.
 The `finish` event is emitted after the `client.end()` method has been
 called, and all data has been flushed to the underlying system.
 
+### `client.sent`
+
+An integer indicating the number of events (spans, transactions, or errors)
+sent by the client. An event is considered sent when the HTTP request
+used to transmit it have ended.
+
 ### `client.sendSpan(span[, callback])`
 
 Send a span to the APM Server.

--- a/index.js
+++ b/index.js
@@ -46,6 +46,8 @@ function Client (opts) {
     if (this._writableState.ending === false) this.destroy()
   }
 
+  this._received = 0 // number of events given to the client for reporting
+  this.sent = 0 // number of events written to the socket
   this._active = false
   this._destroyed = false
   this._onflushed = null
@@ -90,6 +92,7 @@ Client.prototype._write = function (obj, enc, cb) {
       this._chopper.chop(cb)
     }
   } else {
+    this._received++
     this._stream.write(obj, cb)
   }
 }
@@ -205,6 +208,7 @@ function onStream (opts, client, onerror) {
       //    would not get it here as the internal error listener would have
       //    been removed and the stream would throw the error instead
 
+      client.sent = client._received
       client._active = false
       if (client._onflushed) {
         client._onflushed()


### PR DESCRIPTION
This is useful for later doing benchmarks and potentially reporting the number of sent events to the APM Server as a metric. When we have settled on a response JSON format for the APM Server, we can record and expose the number of dropped events as well.