### PR TITLE
test: simplify payloadLogFile test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -325,11 +325,10 @@ test('payloadLogFile', function (t) {
     })
   }).client({payloadLogFile: filename}, function (client) {
     client.sendTransaction({req: 1})
-    client.sendSpan({req: 2}, function () {
-      client._chopper.chop() // force the client to make a 2nd request so that we test reusing the file across requests
-      client.sendError({req: 3})
-      client.end()
-    })
+    client.sendSpan({req: 2})
+    client.flush() // force the client to make a 2nd request so that we test reusing the file across requests
+    client.sendError({req: 3})
+    client.end()
   })
 })
 


### PR DESCRIPTION
There was no reason to access the private `_chopper` object, when the `flush()` function does the same job. This even means that it uses the internal queueing of the writeable stream so that we don't have to delay the chop until after the `sendSpan` have finished.