### PR TITLE
fix: report node version not prefixed with 'v'

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ function getMetadata (opts) {
       name: opts.serviceName,
       runtime: {
         name: process.release.name,
-        version: process.version
+        version: process.versions.node
       },
       language: {
         name: 'javascript'

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -72,7 +72,7 @@ function assertMetadata (t, obj) {
   const service = metadata.service
   t.equal(service.name, 'my-service-name')
   t.equal(service.runtime.name, 'node')
-  t.equal(service.runtime.version, process.version)
+  t.equal(service.runtime.version, process.versions.node)
   t.ok(semver.valid(service.runtime.version))
   t.equal(service.language.name, 'javascript')
   t.equal(service.agent.name, 'my-agent-name')

--- a/test/test.js
+++ b/test/test.js
@@ -168,7 +168,7 @@ test('metadata', function (t) {
             version: 'custom-serviceVersion',
             runtime: {
               name: 'node',
-              version: process.version
+              version: process.versions.node
             },
             language: {
               name: 'javascript'
@@ -234,7 +234,7 @@ test('metadata - default values', function (t) {
             name: 'custom-serviceName',
             runtime: {
               name: 'node',
-              version: process.version
+              version: process.versions.node
             },
             language: {
               name: 'javascript'


### PR DESCRIPTION
Not sure how important this is, but I think it's better to store the "pure" version. This way it's also the same format as the `framework.version`, `version` and `agent.version`