### PR TITLE
refactor: use new chopper transform feature to gzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,20 @@ be emitted, and no more data can be sent by the client.
 Emitted if an error occurs. The listener callback is passed a single
 Error argument when called.
 
-The client is not closed when the `error` event is emitted.
-
 ### Event: `finish`
 
 The `finish` event is emitted after the `client.end()` method has been
 called, and all data has been flushed to the underlying system.
+
+### Event: `request-error`
+
+Emitted if an error occurs while communicating with the APM Server. The
+listener callback is passed a single Error argument when called.
+
+This means that the current request to the APM Server is terminated and
+that the data included in that request is lost.
+
+The client is not closed when the `request-error` event is emitted.
 
 ### `client.sent`
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function Client (opts) {
   Writable.call(this, opts)
 
   const errorproxy = (err) => {
-    if (this._destroyed === false) this.emit('error', err)
+    if (this._destroyed === false) this.emit('request-error', err)
   }
 
   const fail = () => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fast-stream-to-buffer": "^1.0.0",
     "pump": "^3.0.0",
     "readable-stream": "^2.3.6",
-    "stream-chopper": "^1.1.1",
+    "stream-chopper": "^3.0.1",
     "unicode-byte-truncate": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes a bug where the max size of the HTTP body (750kb) was wrongly counted towards the uncompressed bytes. The new version of stream-chopper will count towards the compressed bytes instead.