### PR TITLE
fix: abort current request if server responds early

### DIFF
--- a/test/abort.js
+++ b/test/abort.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const test = require('tape')
+const utils = require('./lib/utils')
+
+const APMServer = utils.APMServer
+const processReq = utils.processReq
+const assertReq = utils.assertReq
+const assertMetadata = utils.assertMetadata
+const assertEvent = utils.assertEvent
+
+test('abort request if server responds early', function (t) {
+  t.plan(assertReq.asserts * 2 + assertMetadata.asserts + assertEvent.asserts + 2)
+
+  let reqs = 0
+  let client
+
+  const datas = [
+    assertMetadata,
+    assertEvent({span: {foo: 2}})
+  ]
+
+  const timer = setTimeout(function () {
+    throw new Error('the test got stuck')
+  }, 5000)
+
+  const server = APMServer(function (req, res) {
+    const reqNo = ++reqs
+
+    assertReq(t, req)
+
+    if (reqNo === 1) {
+      res.writeHead(500)
+      res.end('bad')
+
+      // Wait a little to ensure the current stream have ended, so the next
+      // span will force a new stream to be created
+      setTimeout(function () {
+        client.sendSpan({foo: 2})
+        client.flush()
+      }, 50)
+    } else if (reqNo === 2) {
+      req = processReq(req)
+      req.on('data', function (obj) {
+        datas.shift()(t, obj)
+      })
+      req.on('end', function () {
+        res.end()
+        clearTimeout(timer)
+        server.close()
+        t.end()
+      })
+    } else {
+      t.fail('should not get more than two requests')
+    }
+  }).client(function (_client) {
+    client = _client
+    client.sendSpan({foo: 1})
+    client.on('request-error', function (err) {
+      t.equal(err.code, 500, 'should generate request-error with 500 status code')
+      t.equal(err.response, 'bad', 'should generate request-error with expected body')
+    })
+  })
+})

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -92,7 +92,7 @@ function assertMetadata (t, obj) {
   t.ok(Array.isArray(_process.argv), 'process.title should be an array')
   t.ok(_process.argv.length >= 2, 'process.title should contain at least two elements')
   t.ok(/\/node$/.test(_process.argv[0]), `process.argv[0] should match /\\/node$/ (was: ${_process.argv[0]})`)
-  const regex = /(\/test\/(test|truncate|lib\/unref-client)\.js|node_modules\/\.bin\/tape)$/
+  const regex = /(\/test\/(test|truncate|abort|lib\/unref-client)\.js|node_modules\/\.bin\/tape)$/
   t.ok(regex.test(_process.argv[1]), `process.argv[1] should match ${regex} (was: ${_process.argv[1]})"`)
   const system = metadata.system
   t.ok(typeof system.hostname, 'string')


### PR DESCRIPTION
If the server responds before the client have ended the request, it means something didn't go as planned and the server have given up trying to process the request. It therefore doesn't serve any purpose to continue sending data to the server in that request and we should abort.