### PR TITLE
fix(truncate): ensure context truncate has max

### DIFF
--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -239,8 +239,7 @@ function contextLength (path, opts) {
 
     case 'tags':
       return opts.truncateKeywordsAt
-
-    default:
-      return opts.truncateStringsAt
   }
+
+  return opts.truncateStringsAt
 }


### PR DESCRIPTION
There was a bug in the context max length check that allowed it to have an `undefined` value for max.