### PR TITLE
feat(options): get cgroups container info

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ Data sent to the APM Server as part of the metadata package:
 - `frameworkVersion` - If the service being instrumented is running a
   specific framework, use this config option to log its version
 - `hostname` - Custom hostname (default: OS hostname)
+- `containerId` - Docker container id, if not given will be parsed from `/proc/self/cgroup`
 - `kubernetesNodeName` - Kubernetes node name
 - `kubernetesNamespace` - Kubernetes namespace
-- `kubernetesPodName` - Kubernetes pod name
-- `kubernetesPodUID` - Kubernetes pod id
+- `kubernetesPodName` - Kubernetes pod name, if not given will be the hostname
+- `kubernetesPodUID` - Kubernetes pod id, if not given will be parsed from `/proc/self/cgroup`
 
 HTTP client configuration:
 

--- a/index.js
+++ b/index.js
@@ -415,6 +415,9 @@ function normalizeOptions (opts) {
     if (!normalized.kubernetesPodUID && containerInfo.podId) {
       normalized.kubernetesPodUID = containerInfo.podId
     }
+    if (!normalized.kubernetesPodName && containerInfo.podId) {
+      normalized.kubernetesPodName = hostname
+    }
   }
 
   return normalized

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const os = require('os')
 const parseUrl = require('url').parse
 const zlib = require('zlib')
 const Writable = require('readable-stream').Writable
+const getContainerInfo = require('container-info')
 const pump = require('pump')
 const eos = require('end-of-stream')
 const streamToBuffer = require('fast-stream-to-buffer')
@@ -23,6 +24,8 @@ const requiredOpts = [
   'serviceName',
   'userAgent'
 ]
+
+const containerInfo = getContainerInfo.sync()
 
 const node8 = process.version.indexOf('v8.') === 0
 
@@ -405,6 +408,15 @@ function normalizeOptions (opts) {
   // process
   normalized.serverUrl = parseUrl(normalized.serverUrl)
 
+  if (containerInfo) {
+    if (!normalized.containerId && containerInfo.containerId) {
+      normalized.containerId = containerInfo.containerId
+    }
+    if (!normalized.kubernetesPodUID && containerInfo.podId) {
+      normalized.kubernetesPodUID = containerInfo.podId
+    }
+  }
+
   return normalized
 }
 
@@ -466,6 +478,12 @@ function getMetadata (opts) {
     payload.service.framework = {
       name: opts.frameworkName,
       version: opts.frameworkVersion
+    }
+  }
+
+  if (opts.containerId) {
+    payload.system.container = {
+      id: opts.containerId
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "breadth-filter": "^1.2.0",
+    "container-info": "^1.0.0",
     "end-of-stream": "^1.4.1",
     "fast-safe-stringify": "^2.0.6",
     "fast-stream-to-buffer": "^1.0.0",

--- a/test/config.js
+++ b/test/config.js
@@ -298,6 +298,7 @@ test('metadata - container info', function (t) {
       })
       t.deepEqual(obj.metadata.kubernetes, {
         pod: {
+          name: os.hostname(),
           uid: 'pod-id'
         }
       })


### PR DESCRIPTION
Read container info from `/proc/self/cgroup` to get docker container id and kubernetes pod id default values.