### PR TITLE
fix: stringify header values

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const eos = require('end-of-stream')
 const streamToBuffer = require('fast-stream-to-buffer')
 const StreamChopper = require('stream-chopper')
 const ndjson = require('./lib/ndjson')
+const stringify = require('./lib/stringify')
 const truncate = require('./lib/truncate')
 const pkg = require('./package')
 
@@ -211,12 +212,14 @@ Client.prototype._encode = function (obj, enc) {
       truncate.span(obj.span, this._opts)
       break
     case Client.encoding.TRANSACTION:
+      stringify.context(obj.transaction.context)
       truncate.transaction(obj.transaction, this._opts)
       break
     case Client.encoding.METADATA:
       truncate.metadata(obj.metadata, this._opts)
       break
     case Client.encoding.ERROR:
+      stringify.context(obj.error.context)
       truncate.error(obj.error, this._opts)
       break
     case Client.encoding.METRICSET:

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,0 +1,27 @@
+'use strict'
+
+exports.context = function (context) {
+  if (!context) return
+
+  if (context.request) stringifyHeaders(context.request.headers)
+  if (context.response) stringifyHeaders(context.response.headers)
+}
+
+// Ensure all values in the headers object are either strings or array of strings
+function stringifyHeaders (headers) {
+  if (!headers) return
+
+  for (const key in headers) {
+    const value = headers[key]
+    if (typeof value === 'string') continue
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        if (typeof value[i] !== 'string') {
+          value.splice(i, 1, String(value[i]))
+        }
+      }
+    } else {
+      headers[key] = String(value)
+    }
+  }
+}

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -17,7 +17,7 @@ function stringifyHeaders (headers) {
     if (Array.isArray(value)) {
       for (let i = 0; i < value.length; i++) {
         if (typeof value[i] !== 'string') {
-          value.splice(i, 1, String(value[i]))
+          value[i] = String(value[i])
         }
       }
     } else {

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -92,7 +92,7 @@ function assertMetadata (t, obj) {
   t.ok(Array.isArray(_process.argv), 'process.title should be an array')
   t.ok(_process.argv.length >= 2, 'process.title should contain at least two elements')
   t.ok(/\/node$/.test(_process.argv[0]), `process.argv[0] should match /\\/node$/ (was: ${_process.argv[0]})`)
-  const regex = /(\/test\/(test|truncate|abort|edge-cases|lib\/unref-client)\.js|node_modules\/\.bin\/tape)$/
+  const regex = /(\/test\/(test|stringify|truncate|abort|edge-cases|lib\/unref-client)\.js|node_modules\/\.bin\/tape)$/
   t.ok(regex.test(_process.argv[1]), `process.argv[1] should match ${regex} (was: ${_process.argv[1]})"`)
   const system = metadata.system
   t.ok(typeof system.hostname, 'string')

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const test = require('tape')
+const utils = require('./lib/utils')
+
+const APMServer = utils.APMServer
+const processReq = utils.processReq
+const assertReq = utils.assertReq
+const assertMetadata = utils.assertMetadata
+const assertEvent = utils.assertEvent
+
+const dataTypes = ['transaction', 'error']
+const properties = ['request', 'response']
+
+const upper = {
+  transaction: 'Transaction',
+  error: 'Error'
+}
+
+dataTypes.forEach(function (dataType) {
+  properties.forEach(function (prop) {
+    const sendFn = 'send' + upper[dataType]
+
+    test(`stringify ${dataType} ${prop} headers`, function (t) {
+      t.plan(assertReq.asserts + assertMetadata.asserts + assertEvent.asserts)
+      const datas = [
+        assertMetadata,
+        assertEvent({ [dataType]: {
+          context: {
+            [prop]: {
+              headers: {
+                string: 'foo',
+                number: '42',
+                bool: 'true',
+                nan: 'NaN',
+                object: '[object Object]',
+                array: ['foo', '42', 'true', 'NaN', '[object Object]']
+              }
+            }
+          }
+        } })
+      ]
+      const server = APMServer(function (req, res) {
+        assertReq(t, req)
+        req = processReq(req)
+        req.on('data', function (obj) {
+          datas.shift()(t, obj)
+        })
+        req.on('end', function () {
+          res.end()
+          server.close()
+          t.end()
+        })
+      }).client(function (client) {
+        client[sendFn]({
+          context: {
+            [prop]: {
+              headers: {
+                string: 'foo',
+                number: 42,
+                bool: true,
+                nan: NaN,
+                object: { foo: 'bar' },
+                array: ['foo', 42, true, NaN, { foo: 'bar' }]
+              }
+            }
+          }
+        })
+        client.flush()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Normally headers will always be strings or array of strings, but in case they have been parsed upstream, we must make sure to stringify them here before sending them to the server.