### PR TITLE
fix(package): bump container-info to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "breadth-filter": "^2.0.0",
-    "container-info": "^1.0.0",
+    "container-info": "^1.0.1",
     "end-of-stream": "^1.4.1",
     "fast-safe-stringify": "^2.0.6",
     "fast-stream-to-buffer": "^1.0.0",


### PR DESCRIPTION
This fixes an issue with the Kubernetes container info not being reported automatically.