### PR TITLE
fix: add kubernetes metadata correctly to payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -505,18 +505,14 @@ function getMetadata (opts) {
   }
 
   if (opts.kubernetesNodeName || opts.kubernetesNamespace || opts.kubernetesPodName || opts.kubernetesPodUID) {
-    payload.kubernetes = {
+    payload.system.kubernetes = {
       namespace: opts.kubernetesNamespace,
-      node: undefined,
-      pod: undefined
-    }
-
-    if (opts.kubernetesNodeName) {
-      payload.kubernetes.node = { name: opts.kubernetesNodeName }
-    }
-
-    if (opts.kubernetesPodName || opts.kubernetesPodUID) {
-      payload.kubernetes.pod = { name: opts.kubernetesPodName, uid: opts.kubernetesPodUID }
+      node: opts.kubernetesNodeName
+        ? { name: opts.kubernetesNodeName }
+        : undefined,
+      pod: (opts.kubernetesPodName || opts.kubernetesPodUID)
+        ? { name: opts.kubernetesPodName, uid: opts.kubernetesPodUID }
+        : undefined
     }
   }
 

--- a/test/config.js
+++ b/test/config.js
@@ -296,7 +296,7 @@ test('metadata - container info', function (t) {
       t.deepEqual(obj.metadata.system.container, {
         id: 'container-id'
       })
-      t.deepEqual(obj.metadata.kubernetes, {
+      t.deepEqual(obj.metadata.system.kubernetes, {
         pod: {
           name: os.hostname(),
           uid: 'pod-id'

--- a/test/k8s.js
+++ b/test/k8s.js
@@ -28,7 +28,7 @@ test('kubernetesNodeName only', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, { node: { name: 'foo' } })
+      t.deepEqual(obj.metadata.system.kubernetes, { node: { name: 'foo' } })
     })
     req.on('end', function () {
       res.end()
@@ -47,7 +47,7 @@ test('kubernetesNamespace only', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, { namespace: 'foo' })
+      t.deepEqual(obj.metadata.system.kubernetes, { namespace: 'foo' })
     })
     req.on('end', function () {
       res.end()
@@ -66,7 +66,7 @@ test('kubernetesPodName only', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, { pod: { name: 'foo' } })
+      t.deepEqual(obj.metadata.system.kubernetes, { pod: { name: 'foo' } })
     })
     req.on('end', function () {
       res.end()
@@ -85,7 +85,7 @@ test('kubernetesPodUID only', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, { pod: { uid: 'foo' } })
+      t.deepEqual(obj.metadata.system.kubernetes, { pod: { uid: 'foo' } })
     })
     req.on('end', function () {
       res.end()
@@ -104,7 +104,7 @@ test('all', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, {
+      t.deepEqual(obj.metadata.system.kubernetes, {
         namespace: 'bar',
         node: { name: 'foo' },
         pod: { name: 'baz', uid: 'qux' }
@@ -127,7 +127,7 @@ test('all except kubernetesNodeName', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, {
+      t.deepEqual(obj.metadata.system.kubernetes, {
         namespace: 'bar',
         pod: { name: 'baz', uid: 'qux' }
       })
@@ -149,7 +149,7 @@ test('all except kubernetesNamespace', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, {
+      t.deepEqual(obj.metadata.system.kubernetes, {
         node: { name: 'foo' },
         pod: { name: 'baz', uid: 'qux' }
       })
@@ -171,7 +171,7 @@ test('all except kubernetesPodName', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, {
+      t.deepEqual(obj.metadata.system.kubernetes, {
         namespace: 'bar',
         node: { name: 'foo' },
         pod: { uid: 'qux' }
@@ -194,7 +194,7 @@ test('all except kubernetesPodUID', function (t) {
   const server = APMServer(function (req, res) {
     req = processReq(req)
     req.once('data', function (obj) {
-      t.deepEqual(obj.metadata.kubernetes, {
+      t.deepEqual(obj.metadata.system.kubernetes, {
         namespace: 'bar',
         node: { name: 'foo' },
         pod: { name: 'baz' }


### PR DESCRIPTION
Previously the Kubernetes metadata was added to `meatadata.kubernetes`, but the APM Server expects it to be under `metadata.system.kubernetes`, so it was just silently dropped.

I took the liberty to limit the creation of hidden classes a bit while I was touching the code. It's not a hot code path, so it's not a big deal, but I thought I'd do it anyway.