### PR TITLE
fix: cork timer should be cleared on destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,6 +382,10 @@ Client.prototype._destroy = function (err, cb) {
     clearTimeout(this._configTimer)
     this._configTimer = null
   }
+  if (this._corkTimer) {
+    clearTimeout(this._corkTimer)
+    this._corkTimer = null
+  }
   clients[this._index] = null // remove global reference to ease garbage collection
   this._chopper.destroy()
   this._agent.destroy()


### PR DESCRIPTION
This ensures the cork timer is cleared when the stream is destroyed.