### PR TITLE
fix: race-condition that could leave stream in corked state

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,7 +310,10 @@ Client.prototype._maybeUncork = function () {
       if (this.destroyed === false) this.uncork()
     })
 
-    if (this._corkTimer) clearTimeout(this._corkTimer)
+    if (this._corkTimer) {
+      clearTimeout(this._corkTimer)
+      this._corkTimer = null
+    }
   }
 }
 


### PR DESCRIPTION
If running Node.js 10.2.0 or newer, a race condition would occur in the following scenarios that would leave the stream permanently corked:

- Call `flush` while the stream is corked and `bufferWindowTime !== -1`
- Call `sendSpan`, `sendTransaction`, `sendError`, or `sendMetricSet` while stream is corked, `bufferWindowTime === -1` and `_writableState.length >= bufferWindowSize`.