### PR TITLE
test: allow test/side-effects.js to be run stand-alone

### DIFF
--- a/test/side-effects.js
+++ b/test/side-effects.js
@@ -41,7 +41,6 @@ test('client should not hold the process open', function (t) {
       const start = Number(stdout)
       const duration = end - start
       t.ok(duration < 300, `should not take more than 300 ms to complete (was: ${duration})`)
-      t.end()
     })
   })
 })


### PR DESCRIPTION
If running `tape test/*.js`, the tests inside `test/side-effects.js` would run just fine. But when running the file directly, either via `tape test/side-effects.js` or `node test/side-effects.js`, the tests would fail because of a race-condition.

The race-condition meant that the order of the callback calls would be different. By omitting the `t.end()` call and relying on the `t.plan()` call instead, we get around this issue.