### PR TITLE
ci(jenkins): run master on daily basis

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     CODECOV_SECRET = "secret/apm-team/ci/${env.REPO}-codecov"
   }
   options {
-    timeout(time: 10, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-nodejs-http-client'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -22,15 +22,13 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    cron 'H H(3-5) * * 1-5'
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   stages {
     /**
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -42,7 +40,6 @@ pipeline {
       Run tests.
     */
     stage('Test') {
-      agent { label 'docker && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"

--- a/.ci/jobs/apm-nodejs-http-client-mbp.yml
+++ b/.ci/jobs/apm-nodejs-http-client-mbp.yml
@@ -3,3 +3,39 @@
     name: apm-agent-nodejs/apm-nodejs-http-client-mbp
     display-name: APM Node.js http client
     description: APM Node.js http client
+    script-path: .ci/Jenkinsfile
+    scm:
+    - github:
+        branch-discovery: no-pr
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: true
+        notification-context: 'apm-ci'
+        repo: apm-nodejs-http-client
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'

--- a/.ci/jobs/apm-nodejs-http-client-schedule-daily.yml
+++ b/.ci/jobs/apm-nodejs-http-client-schedule-daily.yml
@@ -1,0 +1,25 @@
+---
+- job:
+    name: apm-agent-nodejs/apm-nodejs-http-client-schedule-daily
+    display-name: APM Node.js http client Jobs scheduled daily
+    description: APM Node.js http client Jobs scheduled daily from Monday to Friday
+    project-type: pipeline
+    parameters:
+    - string:
+        name: branch_specifier
+        default: master
+        description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/schedule-daily.groovy
+      scm:
+      - git:
+          url: git@github.com:elastic/apm-nodejs-http-client.git
+          refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+          wipe-workspace: 'True'
+          name: origin
+          shallow-clone: true
+          credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          branches:
+          - $branch_specifier
+    triggers:
+    - timed: 'H H(4-5) * * 1-5'

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -17,42 +17,6 @@
     days-to-keep: '1'
     concurrent: true
     node: linux
-    script-path: .ci/Jenkinsfile
-    scm:
-    - github:
-        branch-discovery: all
-        discover-pr-forks-strategy: merge-current
-        discover-pr-forks-trust: permission
-        discover-pr-origin: merge-current
-        discover-tags: true
-        notification-context: 'apm-ci'
-        repo: apm-nodejs-http-client
-        repo-owner: elastic
-        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
-        ssh-checkout:
-          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
-        build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
-        - change-request:
-            ignore-target-only-changes: false
-        clean:
-          after: true
-          before: true
-        prune: true
-        shallow-clone: true
-        depth: 3
-        do-not-fetch-tags: true
-        submodule:
-          disable: false
-          recursive: true
-          parent-credentials: true
-          timeout: 100
-        timeout: '15'
-        use-author: true
-        wipe-workspace: 'True'
     periodic-folder-trigger: 1d
     prune-dead-branches: true
     publishers:

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'master' }
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron 'H H(3-5) * * 1-5'
+  }
+  stages {
+    stage('Run Tasks'){
+      steps {
+        script {
+          ['master'].each { branch ->
+            build(
+              job: "apm-agent-nodejs/apm-nodejs-http-client-mbp/${branch}",
+              quietPeriod: 10,
+              wait: false
+            )
+          }
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}


### PR DESCRIPTION
## Highlights
- Build on a daily basis the pipeline for the master branch.
- PRs and tags don't run on a daily basis but on a push basis.
- Optimize the number of required agents, as it will reuse the top-level one.