### PR TITLE
fix(truncate): nulls should not be treated as objects

### DIFF
--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -302,7 +302,7 @@ function onArray (value, key, path, isNew) {
 }
 
 function truncateCustomKeys (value, max, keywords) {
-  if (typeof value !== 'object') {
+  if (typeof value !== 'object' || value === null) {
     return value
   }
   const result = value

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -176,7 +176,8 @@ options.forEach(function (opts) {
           type: 'cool-type',
           context: {
             custom: {
-              [genStr('a', customKeyLen)]: 'truncate my key'
+              [genStr('a', customKeyLen)]: 'truncate my key',
+              [genStr('b', customKeyLen)]: null
             },
             db: {
               statement: 'SELECT * FROM USERS'
@@ -203,7 +204,8 @@ options.forEach(function (opts) {
         type: 'cool-type',
         context: {
           custom: {
-            [genStr('a', veryLong)]: 'truncate my key'
+            [genStr('a', veryLong)]: 'truncate my key',
+            [genStr('b', veryLong)]: null
           },
           db: {
             statement: 'SELECT * FROM USERS'


### PR DESCRIPTION
This fixes a bug introduced in #92.