### PR TITLE
fix truncate bug when value is null

### DIFF
--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -302,7 +302,7 @@ function onArray (value, key, path, isNew) {
 }
 
 function truncateCustomKeys (value, max, keywords) {
-  if (typeof value !== 'object') {
+  if (value === null || typeof value !== 'object') {
     return value
   }
   const result = value


### PR DESCRIPTION
This change fixes this bug I was getting when updating from `elastic-apm-node` `3.0.0` -> `3.1.0`.

```
TypeError: Cannot convert undefined or null to object
     at Function.keys (<anonymous>)
     at truncateCustomKeys (/project/node_modules/elastic-apm-http-client/lib/truncate.js:309:23)
     at truncateCustomKeys (/project/node_modules/elastic-apm-http-client/lib/truncate.js:316:22)
     at Object.truncSpan [as span] (/project/node_modules/elastic-apm-http-client/lib/truncate.js:136:12)
     at Client._encode (/project/node_modules/elastic-apm-http-client/index.js:327:27)
     at Client.encodeObject (/project/node_modules/elastic-apm-http-client/index.js:272:15)
     at Array.map (<anonymous>)
     at Client._writevCleaned (/project/node_modules/elastic-apm-http-client/index.js:276:22)
     at processBatch (/project/node_modules/elastic-apm-http-client/index.js:250:12)
     at Client._writev (/project/node_modules/elastic-apm-http-client/index.js:268:3)
     at doWrite (/project/node_modules/elastic-apm-http-client/node_modules/readable-stream/lib/_stream_writable.js:405:97)
     at clearBuffer (/project/node_modules/elastic-apm-http-client/node_modules/readable-stream/lib/_stream_writable.js:501:5)
     at Client.Writable.uncork (/project/node_modules/elastic-apm-http-client/node_modules/readable-stream/lib/_stream_writable.js:317:94)
     at Timeout._onTimeout (/project/node_modules/elastic-apm-http-client/index.js:299:14)
     at listOnTimeout (internal/timers.js:531:17)
     at processTimers (internal/timers.js:475:7)
```

`null` is considered an object so if a field had null when it gets to the `truncateCustomKeys` functions it would fail.

I would have objects getting passed to this function with `action`, `subtype`, and `context` set to `null`.