### PR TITLE
Add serverCaCert option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ HTTP client configuration:
 - `rejectUnauthorized` - Set to `false` if the client shouldn't verify
   the APM Server TLS certificates (default: `true`)
 - `serverCaCert` - The CA certificate used to verify the APM Server's
-  TLS certificate.
+  TLS certificate, and has the same requirements as the `ca` option
+  of [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options).
 - `serverTimeout` - HTTP request timeout in milliseconds. If no data is
   sent or received on the socket for this amount of time, the request
   will be aborted. It's not recommended to set a `serverTimeout` lower

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ HTTP client configuration:
   the APM Server TLS certificates (default: `true`)
 - `serverCaCert` - The CA certificate used to verify the APM Server's
   TLS certificate, and has the same requirements as the `ca` option
-  of [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options).
+  of [`tls.createSecureContext`](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options).
 - `serverTimeout` - HTTP request timeout in milliseconds. If no data is
   sent or received on the socket for this amount of time, the request
   will be aborted. It's not recommended to set a `serverTimeout` lower

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ HTTP client configuration:
   used when making HTTP requests to he APM Server
 - `rejectUnauthorized` - Set to `false` if the client shouldn't verify
   the APM Server TLS certificates (default: `true`)
+- `serverCaCert` - The CA certificate used to verify the APM Server's
+  TLS certificate.
 - `serverTimeout` - HTTP request timeout in milliseconds. If no data is
   sent or received on the socket for this amount of time, the request
   will be aborted. It's not recommended to set a `serverTimeout` lower

--- a/index.js
+++ b/index.js
@@ -533,6 +533,7 @@ function getBasicRequestOptions (method, defaultPath, headers, opts, agent) {
   return {
     agent: agent,
     rejectUnauthorized: opts.rejectUnauthorized !== false,
+    ca: opts.serverCaCert,
     hostname: opts.serverUrl.hostname,
     port: opts.serverUrl.port,
     method,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "codecov": "^3.6.1",
-    "https-pem": "^2.0.0",
     "ndjson": "^1.5.0",
     "nyc": "^14.1.1",
     "semver": "^6.3.0",

--- a/test/config.js
+++ b/test/config.js
@@ -149,6 +149,20 @@ test('allow unauthorized TLS if asked', function (t) {
   })
 })
 
+test('allow self-signed TLS certificate by specifying the CA', function (t) {
+  t.plan(1)
+  const server = APMServer({ secure: true }, function (req, res) {
+    t.pass('should let request through')
+    res.end()
+    server.close()
+    t.end()
+  })
+  server.client({ serverCaCert: server.cert }, function (client) {
+    client.sendSpan({ foo: 42 })
+    client.end()
+  })
+})
+
 test('metadata', function (t) {
   t.plan(12)
   const opts = {

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -5,7 +5,6 @@ const https = require('https')
 const { URL } = require('url')
 const zlib = require('zlib')
 const semver = require('semver')
-const pem = require('https-pem')
 const ndjson = require('ndjson')
 const pkg = require('../../package')
 const Client = require('../../')
@@ -25,7 +24,7 @@ function APMServer (opts, onreq) {
   const secure = !!opts.secure
 
   const server = secure
-    ? https.createServer(pem, onreq)
+    ? https.createServer({ cert: tlsCert, key: tlsKey }, onreq)
     : http.createServer(onreq)
 
   // Because we use a keep-alive agent in the client, we need to unref the
@@ -158,3 +157,45 @@ function validOpts (opts) {
     userAgent: 'my-user-agent'
   }, opts)
 }
+
+// tlsCert and tlsKey were generated via the same method as Go's builtin
+// test certificate/key pair, using
+// https://github.com/golang/go/blob/master/src/crypto/tls/generate_cert.go:
+//
+//     go run generate_cert.go --rsa-bits 1024 --host 127.0.0.1,::1,localhost \
+//                             --ca --start-date "Jan 1 00:00:00 1970" \
+//                             --duration=1000000h
+//
+// The certificate is valid for 127.0.0.1, ::1, and localhost; and expires in the year 2084.
+
+const tlsCert = `-----BEGIN CERTIFICATE-----
+MIICETCCAXqgAwIBAgIQQalo5z3llnTiwERMPZQxujANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDrW9Z8jSgTMeN9Dt36HBj/kbU/aeFp10GshKm8IKWBpyyWKrTSjiYJIpTK
+l/6sdC77UCDokYAk66T+IXIvvRvqOtD1HUt+KLlqZ7acunTp1Qq4PnASHBm9fdKs
+F1c8gWlEXOMzCsC5BmokcijW7z8JTKszAVi2vpq5MHbtYxZXKQIDAQABo2YwZDAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAsBgNVHREEJTAjgglsb2NhbGhvc3SHBH8AAAGHEAAAAAAAAAAAAAAAAAAA
+AAEwDQYJKoZIhvcNAQELBQADgYEA4yzI/6gjkACdvrnlFm/MJlDQztPYYEAtQ6Sp
+0q0PMQcynLfhH94KMjxJb31HNPJYXr7UrE6gwL2sUnfioXUTQTk35okpphR8MGu2
+hZ704px4wdeK/9B5Vh96oMZLYhm9SXizRVAZz7bPFYNMrhyk9lrWZXOaX526w4wI
+Y5LTiUQ=
+-----END CERTIFICATE-----`
+
+const tlsKey = `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAOtb1nyNKBMx430O
+3focGP+RtT9p4WnXQayEqbwgpYGnLJYqtNKOJgkilMqX/qx0LvtQIOiRgCTrpP4h
+ci+9G+o60PUdS34ouWpntpy6dOnVCrg+cBIcGb190qwXVzyBaURc4zMKwLkGaiRy
+KNbvPwlMqzMBWLa+mrkwdu1jFlcpAgMBAAECgYEAtZc9LQooIm86izHeWOw26XD9
+u/iwf94igL42y70QlbFreE1pCI++jwvMa2fMijh2S1bunSIuEc5yldUuaeDp2FtJ
+k7U9orbJspnWy6ixk1KgpjffdHP73r4S3a5G81G8sq9Uvwl0vxF90eTvg9C7kUfk
+J1YMy4zcpLtwkCHEkNUCQQDx79t6Dqswi8vDoS0+MCIJNCO4J49ZchL8aXE8n9GT
+mF+eOsKy6e5qYH0oYPpeXchwf1tWhX1gBCb3fXrtOoPTAkEA+QoX9S1XofY8YS1M
+iNVVSkLjpKgVoTQVe4j+vj16NHouVQ+oOvEUca2LTrHRx+utdar1NSexl51NO0Lj
+3sqnkwJAPNWCC3Pqyb8tEljRxoRV2piYrrKL0gLkEUH2LjdFfGZhDKlb0Z8OywLO
+Fbwk2FuejeMINX5FY0JIBg0wPrxq7wJAMoot2n/dLO0/y6jZw1sn9+4jLKM/4Hsl
+cPCYYhsv1b6F8JVA2tVaBMfnYY0MubnGdf6/zI3FqLMvnTsx62DNKQJBAMYUaw/D
+plXTexeEU/c0BRxQdOkGmDqOQtnuRQUCQq6gu+occTeilgFoKHWT3QcZHIpHxawJ
+N2K67EWPRgr3suE=
+-----END PRIVATE KEY-----`


### PR DESCRIPTION
We add support for specifying the CA certificate
for verifying the server's TLS certificate chain.

Update the tests to use a self-signed certificate
that is valid for "localhost", rather than the
one generated by selfsigned, which is valid for
"example.org". This certificate also has a much
longer expiry time, which avoids having to reinstall
http-pem after a year.

This is in support of https://github.com/elastic/apm-agent-nodejs/issues/1508