### PR TITLE
Support api keys for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ HTTP client configuration:
 - `userAgent` - (required) The HTTP user agent that your module should
   identify it self as
 - `secretToken` - The Elastic APM intake API secret token
+- `apiKey` - Elastic APM API key
 - `serverUrl` - The APM Server URL (default: `http://localhost:8200`)
 - `headers` - An object containing extra HTTP headers that should be
   used when making HTTP requests to he APM Server

--- a/index.js
+++ b/index.js
@@ -545,6 +545,7 @@ function getBasicRequestOptions (method, defaultPath, headers, opts, agent) {
 function getHeaders (opts) {
   const headers = {}
   if (opts.secretToken) headers.Authorization = 'Bearer ' + opts.secretToken
+  if (opts.apiKey) headers.Authorization = 'ApiKey ' + opts.apiKey
   headers.Accept = 'application/json'
   headers['User-Agent'] = `${opts.userAgent} ${pkg.name}/${pkg.version} ${process.release.name}/${process.versions.node}`
   return Object.assign(headers, opts.headers)

--- a/test/config.js
+++ b/test/config.js
@@ -58,7 +58,7 @@ test('null value config options shouldn\'t throw', function (t) {
   t.end()
 })
 
-test('no secretToken', function (t) {
+test('no secretToken or apiKey', function (t) {
   t.plan(1)
   const server = APMServer(function (req, res) {
     t.notOk('authorization' in req.headers)
@@ -69,6 +69,24 @@ test('no secretToken', function (t) {
   server.listen(function () {
     const client = new Client(validOpts({
       serverUrl: 'http://localhost:' + server.address().port
+    }))
+    client.sendSpan({ foo: 42 })
+    client.end()
+  })
+})
+
+test('has apiKey', function (t) {
+  t.plan(1)
+  const server = APMServer(function (req, res) {
+    t.equal(req.headers.authorization, 'ApiKey FooBar123', 'should use apiKey in authorization header')
+    res.end()
+    server.close()
+    t.end()
+  })
+  server.listen(function () {
+    const client = new Client(validOpts({
+      serverUrl: 'http://localhost:' + server.address().port,
+      apiKey: 'FooBar123'
     }))
     client.sendSpan({ foo: 42 })
     client.end()


### PR DESCRIPTION
This would allow the apm-agent-nodejs to be used with api keys not only secret tokens.