### PR TITLE
feat: ensure podId conforms to elastic naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,4 @@ subsequent calls to `sendSpan()`, `sendTransaction()`, `sendError()`,
 ## License
 
 [MIT](LICENSE)
+

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { URL } = require('url')
 const zlib = require('zlib')
 const querystring = require('querystring')
 const Writable = require('readable-stream').Writable
-const getContainerInfo = require('container-info')
+const getContainerInfo = require('./lib/container-info')
 const pump = require('pump')
 const eos = require('end-of-stream')
 const streamToBuffer = require('fast-stream-to-buffer')
@@ -26,7 +26,7 @@ const requiredOpts = [
   'userAgent'
 ]
 
-const containerInfo = getContainerInfo.sync()
+const containerInfo = getContainerInfo()
 
 const node8 = process.version.indexOf('v8.') === 0
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const { URL } = require('url')
 const zlib = require('zlib')
 const querystring = require('querystring')
 const Writable = require('readable-stream').Writable
-const getContainerInfo = require('./lib/container-info')
+// const getContainerInfo = require('./lib/container-info')
+const getContainerInfo = require('container-info')
 const pump = require('pump')
 const eos = require('end-of-stream')
 const streamToBuffer = require('fast-stream-to-buffer')
@@ -26,7 +27,8 @@ const requiredOpts = [
   'userAgent'
 ]
 
-const containerInfo = getContainerInfo()
+const containerInfo = getContainerInfo.sync()
+// const containerInfo = getContainerInfo()
 
 const node8 = process.version.indexOf('v8.') === 0
 

--- a/lib/container-info.js
+++ b/lib/container-info.js
@@ -1,0 +1,19 @@
+
+const getContainerInfo = require('container-info')
+
+/**
+ * Function that uses `container-info`
+ * package to extract container information
+ * and apply additional naming rules
+ *
+ * Injectable getInfo for testing purposes
+ */
+module.exports = (getInfo = getContainerInfo) => {
+  const info = getInfo.sync()
+  if (!info) { return info }
+
+  if (info.podId) {
+    info.podId = info.podId.replace(/_/g, '-')
+  }
+  return info
+}

--- a/test/container-info.js
+++ b/test/container-info.js
@@ -1,0 +1,74 @@
+const test = require('tape')
+const getContainerInfo = require('container-info')
+const containerInfo = require('../lib/container-info')
+
+const createMockForFixtureString = (source) => {
+  const mock = {
+    sync: () => {
+      const string = source
+      return getContainerInfo.parse(string)
+    }
+  }
+  return mock
+}
+
+test('./lib/container-info ', function (t) {
+  const fixtures = [
+    {
+      source: '12:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope',
+      expectedPodId: '22949dce-fd8b-11ea-8ede-98f2b32c645c'
+    },
+    {
+      source: '11:devices:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '10:perf_event:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '9:memory:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '8:freezer:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '7:hugetlb:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '6:cpuset:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '5:blkio:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '4:cpu,cpuacct:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '3:net_cls,net_prio:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '2:pids:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    },
+    {
+      source: '1:name=systemd:/kubepods/besteffort/pod74c13223-5a00-11e9-b385-42010a80018d/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      expectedPodId: '74c13223-5a00-11e9-b385-42010a80018d'
+    }
+  ]
+  for (const [, fixture] of fixtures.entries()) {
+    const mock = createMockForFixtureString(fixture.source)
+    const info = containerInfo(mock)
+    // console.log(info)
+    t.equals(info.podId, fixture.expectedPodId)
+  }
+
+  t.end()
+})


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-agent-nodejs/issues/1821

This PR ensure the podID we extract from cgroups info [conforms to the following spec change](https://github.com/elastic/apm/pull/344/files).

This change is made here instead of the `container-info` package.  The `container-info` package is in use outside of elastic, and changing it's behavior would impact multiple parties (no _ to - conversion).  Instead we rely on this package to grab the container information, and then make any additional string formatting changes needed by elastic. 

