### PR TITLE
Added support for custom http.Agent. Fixes #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ HTTP client configuration:
   `Infinity`)
 - `maxFreeSockets` - Maximum number of sockets to leave open in a free
   state. Only relevant if `keepAlive` is set to `true` (default: `256`)
+- `agent` - Custom [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent).
+  Typical use case is to swap the default Agent with one compatible with a
+  HTTP proxy, such as [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent)
 
 APM Agent Configuration via Kibana:
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "codecov": "^3.6.1",
+    "https-proxy-agent": "^5.0.0",
     "ndjson": "^1.5.0",
     "nyc": "^14.1.1",
     "semver": "^6.3.0",

--- a/test/agent.js
+++ b/test/agent.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const test = require('tape')
+const utils = require('./lib/utils')
+const HttpsProxyAgent = require('https-proxy-agent')
+const ProxyServer = require('./helpers/ProxyServer')
+
+test('With a custom http.Agent and central config disabled', function (t) {
+  t.plan(1)
+
+  const proxy = new ProxyServer()
+  const server = utils.APMServer(
+    function (req, res) {
+      req.resume()
+      req.on('end', function () {
+        res.end()
+        t.deepEqual([`localhost:${server.address().port}`], proxy.requests, 'Client can traverse a HTTP proxy')
+        server.close()
+        proxy.close()
+        t.end()
+      })
+    })
+
+  proxy.listen(() => {
+    server.client(
+      { agent: new HttpsProxyAgent({ port: proxy.port() }) },
+      (client) => {
+        client.sendTransaction({ foo: 42 })
+        client.flush()
+      })
+  })
+})
+
+test('With a custom http.Agent and central config enabled', function (t) {
+  t.plan(1)
+
+  const proxy = new ProxyServer()
+  const server = utils.APMServer(
+    function (req, res) {
+      req.resume()
+      req.on('end', function () {
+        res.end()
+        t.deepEqual([`localhost:${server.address().port}`], proxy.requests, 'Client can traverse a HTTP proxy')
+        server.close()
+        proxy.close()
+        t.end()
+      })
+    })
+
+  proxy.listen(() => {
+    server.client(
+      { agent: new HttpsProxyAgent({ port: proxy.port() }), centralConfig: true },
+      () => {}) // We do nothing with the client, there's only the central config request
+  })
+})

--- a/test/central-config.js
+++ b/test/central-config.js
@@ -87,7 +87,6 @@ test('polling', function (t) {
         t.end()
         res.writeHead(404) // end nicely so we don't get a request-error
         res.end()
-        client.destroy()
         server.close()
         break
       default:

--- a/test/helpers/ProxyServer.js
+++ b/test/helpers/ProxyServer.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const net = require('net')
+const http = require('http')
+
+module.exports = class ProxyServer {
+  constructor () {
+    this.requests = []
+    this.server = http.createServer()
+
+    this.server.on('connect', (req, client) => {
+      const [host, port] = req.url.split(':')
+      const server = net.connect(port, host, function () {
+        client.write('HTTP/1.1 200 Connection Established\r\n\r\n')
+
+        server.pipe(client).pipe(server)
+      })
+
+      this.requests.push(req.url)
+      server.on('close', () => client.destroy())
+    })
+  }
+
+  listen (callback) {
+    return this.server.listen(callback)
+  }
+
+  close (callback) {
+    return this.server.close(callback)
+  }
+
+  port () {
+    return this.server.address().port
+  }
+}


### PR DESCRIPTION
Hi guys!

Following the discussion in elastic/apm-nodejs-http-client#91 I added support for passing in custom http.Agent instances, in order to be able to traverse HTTP proxies when the APM server you're connecting to is after such a proxy.
My ultimate goal is to make https://github.com/elastic/apm-agent-nodejs support the new setting, any advice on whether I should contribute something there also is welcome :+1: 

Thanks,
David