### PR TITLE
chore: prefer 'files' to .npmignore to control published files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.ci
-.codecov.yml
-.travis.yml
-.nyc_output
-test

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "test": "standard && nyc tape test/*.js"


### PR DESCRIPTION
before:

```
% npm publish --dry-run
npm notice
npm notice 📦  elastic-apm-http-client@9.4.1
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 527B   lib/container-info.js
npm notice 22.4kB index.js
npm notice 280B   lib/ndjson.js
npm notice 7.4kB  lib/truncate.js
npm notice 1.3kB  package.json
npm notice 12.2kB README.md
npm notice 68B    .github/labeler-config.yml
npm notice 350B   .github/workflows/labeler.yml
npm notice === Tarball Details ===
npm notice name:          elastic-apm-http-client
npm notice version:       9.4.1
npm notice package size:  13.8 kB
npm notice unpacked size: 45.6 kB
npm notice shasum:        8c8990ea6172fb0b5910b2532e5958e894cb4209
npm notice integrity:     sha512-w+UaLo9w6BFed[...]BxlIHwX/XJQ8Q==
npm notice total files:   9
npm notice
+ elastic-apm-http-client@9.4.1
```

after:

```
% npm publish --dry-run
npm notice
npm notice 📦  elastic-apm-http-client@9.4.1
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 527B   lib/container-info.js
npm notice 22.4kB index.js
npm notice 280B   lib/ndjson.js
npm notice 7.4kB  lib/truncate.js
npm notice 1.4kB  package.json
npm notice 12.2kB README.md
npm notice === Tarball Details ===
npm notice name:          elastic-apm-http-client
npm notice version:       9.4.1
npm notice package size:  13.5 kB
npm notice unpacked size: 45.3 kB
npm notice shasum:        546335c41163fda9afbb50ff078652473b49fc9f
npm notice integrity:     sha512-V90FecfFrVuuK[...]f9qXPxi2QBR/Q==
npm notice total files:   7
npm notice
+ elastic-apm-http-client@9.4.1
```

You see that we now avoid publishing the '.github/' files that weren't added to .npmignore before.