### PR TITLE
Accept Cloud Metadata Payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -621,7 +621,7 @@ function getMetadata (opts) {
   }
 
   if (opts.cloudMetadata) {
-    payload.cloud = Object.assign({},opts.cloudMetadata)
+    payload.cloud = Object.assign({}, opts.cloudMetadata)
   }
 
   return payload

--- a/index.js
+++ b/index.js
@@ -620,6 +620,10 @@ function getMetadata (opts) {
     }
   }
 
+  if(opts.cloud) {
+    payload.cloud = opts.cloud
+  }
+
   return payload
 }
 

--- a/index.js
+++ b/index.js
@@ -620,8 +620,8 @@ function getMetadata (opts) {
     }
   }
 
-  if(opts.cloud) {
-    payload.cloud = opts.cloud
+  if (opts.cloudMetadata) {
+    payload.cloud = Object.assign({},opts.cloudMetadata)
   }
 
   return payload

--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -58,41 +58,44 @@ function truncMetadata (metadata, opts) {
           }
           break
         case 'cloud':
-          switch(path[1]) {
+          switch (path[1]) {
             case 'availability_zone':
             case 'provider':
             case 'region':
               max = opts.truncateKeywordsAt
               break
             case 'account':
-              switch(path[2]) {
+              switch (path[2]) {
                 case 'id':
                 case 'name':
                   max = opts.truncateKeywordsAt
                   break
               }
+              break
             case 'instance':
-              switch(path[2]) {
+              switch (path[2]) {
                 case 'id':
                 case 'name':
                   max = opts.truncateKeywordsAt
                   break
               }
+              break
             case 'machine':
-              switch(path[2]) {
+              switch (path[2]) {
                 case 'type':
                   max = opts.truncateKeywordsAt
                   break
               }
+              break
             case 'project':
-              switch(path[2]) {
+              switch (path[2]) {
                 case 'id':
                 case 'name':
                   max = opts.truncateKeywordsAt
                   break
               }
           }
-          break;
+          break
       }
 
       return truncate(value, max)

--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -57,6 +57,42 @@ function truncMetadata (metadata, opts) {
               break
           }
           break
+        case 'cloud':
+          switch(path[1]) {
+            case 'availability_zone':
+            case 'provider':
+            case 'region':
+              max = opts.truncateKeywordsAt
+              break
+            case 'account':
+              switch(path[2]) {
+                case 'id':
+                case 'name':
+                  max = opts.truncateKeywordsAt
+                  break
+              }
+            case 'instance':
+              switch(path[2]) {
+                case 'id':
+                case 'name':
+                  max = opts.truncateKeywordsAt
+                  break
+              }
+            case 'machine':
+              switch(path[2]) {
+                case 'type':
+                  max = opts.truncateKeywordsAt
+                  break
+              }
+            case 'project':
+              switch(path[2]) {
+                case 'id':
+                case 'name':
+                  max = opts.truncateKeywordsAt
+                  break
+              }
+          }
+          break;
       }
 
       return truncate(value, max)

--- a/test/config.js
+++ b/test/config.js
@@ -467,7 +467,7 @@ test('metadata - cloud info', function (t) {
   // will pass that config key on into the generated
   // metadata
   const optsTestFixture = {
-    cloud:{foo:'bar'}
+    cloudMetadata: { foo: 'bar' }
   }
   // Clear Client and APMServer from require cache
   delete require.cache[require.resolve('../')]
@@ -479,7 +479,7 @@ test('metadata - cloud info', function (t) {
     req = processIntakeReq(req)
     req.once('data', function (obj) {
       t.ok(obj.metadata.cloud, 'cloud metadata set')
-      t.deepEqual(obj.metadata.cloud, optsTestFixture.cloud, 'cloud metadata passed through')
+      t.deepEqual(obj.metadata.cloud, optsTestFixture.cloudMetadata, 'cloud metadata passed through')
     })
     req.on('end', function () {
       res.end()

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -406,7 +406,6 @@ function genStr (ch, length) {
   return new Array(length + 1).join(ch)
 }
 
-
 test('truncate cloud metadata', function (t) {
   // tests that each cloud metadata field is truncated
   // at `truncateKeywordsAt` values
@@ -417,28 +416,28 @@ test('truncate cloud metadata', function (t) {
 
   const longString = (new Array(500).fill('x').join(''))
   const toTruncate = {
-    "cloud": {
-      "account": {
-        "id": longString,
-        "name": longString
+    cloud: {
+      account: {
+        id: longString,
+        name: longString
       },
-      "availability_zone": longString,
-      "instance": {
-        "id": longString,
-        "name": longString
+      availability_zone: longString,
+      instance: {
+        id: longString,
+        name: longString
       },
-      "machine": {
-        "type": longString
+      machine: {
+        type: longString
       },
-      "project": {
-        "id": longString,
-        "name": longString
+      project: {
+        id: longString,
+        name: longString
       },
-      "provider": longString,
-      "region": longString
+      provider: longString,
+      region: longString
     }
   }
-  const {cloud} = truncate.metadata(toTruncate,opts)
+  const { cloud } = truncate.metadata(toTruncate, opts)
 
   t.ok(cloud.account.id.length === 100, 'account.id.length was truncated')
   t.ok(cloud.account.name.length === 100, 'account.name.length was truncated')

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -8,6 +8,7 @@ const processIntakeReq = utils.processIntakeReq
 const assertIntakeReq = utils.assertIntakeReq
 const assertMetadata = utils.assertMetadata
 const assertEvent = utils.assertEvent
+const truncate = require('../lib/truncate')
 
 const options = [
   {}, // default options
@@ -404,3 +405,51 @@ options.forEach(function (opts) {
 function genStr (ch, length) {
   return new Array(length + 1).join(ch)
 }
+
+
+test('truncate cloud metadata', function (t) {
+  // tests that each cloud metadata field is truncated
+  // at `truncateKeywordsAt` values
+  const opts = {
+    truncateKeywordsAt: 100,
+    truncateStringsAt: 50
+  }
+
+  const longString = (new Array(500).fill('x').join(''))
+  const toTruncate = {
+    "cloud": {
+      "account": {
+        "id": longString,
+        "name": longString
+      },
+      "availability_zone": longString,
+      "instance": {
+        "id": longString,
+        "name": longString
+      },
+      "machine": {
+        "type": longString
+      },
+      "project": {
+        "id": longString,
+        "name": longString
+      },
+      "provider": longString,
+      "region": longString
+    }
+  }
+  const {cloud} = truncate.metadata(toTruncate,opts)
+
+  t.ok(cloud.account.id.length === 100, 'account.id.length was truncated')
+  t.ok(cloud.account.name.length === 100, 'account.name.length was truncated')
+  t.ok(cloud.availability_zone.length === 100, 'availability_zone was truncated')
+  t.ok(cloud.instance.id.length === 100, 'instance.id was truncated')
+  t.ok(cloud.instance.name.length === 100, 'instance.name was truncated')
+  t.ok(cloud.machine.type.length === 100, 'machine.type was truncated')
+  t.ok(cloud.project.id.length === 100, 'project.id was truncated')
+  t.ok(cloud.project.name.length === 100, 'project.name was truncated')
+  t.ok(cloud.provider.length === 100, 'provider was truncated')
+  t.ok(cloud.region.length === 100, 'region was truncated')
+
+  t.end()
+})


### PR DESCRIPTION
This is the HTTP client portion of https://github.com/elastic/apm-agent-nodejs/issues/1815

This PR

1. Adds a new top level `cloudMetadata` configuration field to the configuration options
2. Passes this data on to the `cloud` key of the metadata payload that's sent to APM server
3. Implements truncation rules, following the pattern set for other metadata fields

This PR treats the client as a dumb pipe and does not make heroic efforts to validate the data, (other than truncating too long data, as #3)

Spec: https://github.com/elastic/apm/blob/3f224a9cbacb196bbb196b0868d9fa90a0bbaf6c/specs/agents/metadata.md#cloud-provider-metadata

Schema: https://github.com/elastic/apm-server/blob/master/docs/spec/v2/metadata.json
