### PR TITLE
fix: destroy request instead of aborting it on timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,7 +450,7 @@ function onStream (client, onerror) {
 
     if (Number.isFinite(client._conf.serverTimeout)) {
       req.setTimeout(client._conf.serverTimeout, function () {
-        req.destroy(new Error(`APM Server didn't responded within ${client._conf.serverTimeout}ms`))
+        req.destroy(new Error(`APM Server response timeout (${client._conf.serverTimeout}ms)`))
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -450,7 +450,7 @@ function onStream (client, onerror) {
 
     if (Number.isFinite(client._conf.serverTimeout)) {
       req.setTimeout(client._conf.serverTimeout, function () {
-        req.abort()
+        req.destroy(new Error(`APM Server didn't responded within ${client._conf.serverTimeout}ms`))
       })
     }
 

--- a/test/edge-cases.js
+++ b/test/edge-cases.js
@@ -336,8 +336,7 @@ test('socket timeout - server response too slow', function (t) {
       const end = Date.now()
       const delta = end - start
       t.ok(delta > 1000 && delta < 2000, 'timeout should occur between 1-2 seconds')
-      t.equal(err.message, 'socket hang up')
-      t.equal(err.code, 'ECONNRESET')
+      t.equal(err.message, 'APM Server didn\'t responded within 1000ms')
       server.close()
       t.end()
     })
@@ -358,8 +357,7 @@ test('socket timeout - client request too slow', function (t) {
       const end = Date.now()
       const delta = end - start
       t.ok(delta > 1000 && delta < 2000, 'timeout should occur between 1-2 seconds')
-      t.equal(err.message, 'socket hang up')
-      t.equal(err.code, 'ECONNRESET')
+      t.equal(err.message, 'APM Server didn\'t responded within 1000ms')
       server.close()
       t.end()
     })

--- a/test/edge-cases.js
+++ b/test/edge-cases.js
@@ -336,7 +336,7 @@ test('socket timeout - server response too slow', function (t) {
       const end = Date.now()
       const delta = end - start
       t.ok(delta > 1000 && delta < 2000, 'timeout should occur between 1-2 seconds')
-      t.equal(err.message, 'APM Server didn\'t responded within 1000ms')
+      t.equal(err.message, 'APM Server response timeout (1000ms)')
       server.close()
       t.end()
     })
@@ -357,7 +357,7 @@ test('socket timeout - client request too slow', function (t) {
       const end = Date.now()
       const delta = end - start
       t.ok(delta > 1000 && delta < 2000, 'timeout should occur between 1-2 seconds')
-      t.equal(err.message, 'APM Server didn\'t responded within 1000ms')
+      t.equal(err.message, 'APM Server response timeout (1000ms)')
       server.close()
       t.end()
     })


### PR DESCRIPTION
req.abort() is deprecated since v14.1.0/v13.14.0 and it's recommended to
use req.destroy() instead.

This also allows us to provide a custom error message, which means we
can know when a socket is closed based an external factor vs. when we
close it ourselves internally.