### PR TITLE
internals docs -- client streams and stream corking

### DIFF
--- a/docs/internals/client-streams.md
+++ b/docs/internals/client-streams.md
@@ -55,7 +55,7 @@ Consider this simple program
     s.write('hello stream')
 ```
 
-The MyStream class allows us to create a stream object which we can
+The `MyStream` class allows us to create a stream object that we can
 write data to. The MyStream object can take action whenever data is
 written to this stream.
 
@@ -101,7 +101,7 @@ Let's look at each stream object independently.
 
 Whenever the Elastic Agent wants to send a piece of data to APM Server,
 it will first call a method on the apm-nodejs-http-client object. You
-can see an example [of that
+can see an example [of this
 here](https://github.com/elastic/apm-agent-nodejs/blob/3c2505b5f299381f09409500b4f0108dbb01ba38/lib/instrumentation/index.js#L241),
 with the agent calling the sendSpan method of the apm-nodejs-http-client
 object.
@@ -146,7 +146,7 @@ The stream-chopper
     stream-chopper will close and destroy the destination-stream object,
     and then create a new destination-stream
 
-5.  If the stream-chopper writes data to a stream passed a configured
+5.  If the stream-chopper writes data to a stream past a
     time limit, the stream-chopper will close and destroy the
     destination-stream object, and then create a new destination-stream
 
@@ -179,7 +179,7 @@ have one destination-stream active at time.
 The apm-nodejs-http-client object instantiates the stream-chopper [in
 its
 constructor](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L95).
-The stream-chopper is a single instance object.
+The stream-chopper is intended to be a long lived single instance object.
 
 ```javascript
     this._chopper = new StreamChopper({
@@ -252,13 +252,13 @@ server. This request object is our our final stream
 
 Both the http and https modules in Node.js provide a low level
 streamable interfaces for making HTTP requests. The request object
-returned by this call to request is a stream object.
+returned by this call to `_transport.request` is a stream object.
 
 Next, the listener function [will
 pipe](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options)
 the data from the zlib stream to the req stream. This means the
 compressed data that the zlib stream is writing will be written to the
-req stream. In other words -- the compressed data coming out of the zlib
+req stream. In other words --- the compressed data coming out of the zlib
 stream will be sent to the APM Server.
 
 Pump vs. Pipe
@@ -267,7 +267,7 @@ Pump vs. Pipe
 Stream piping is [a built-in feature of the Node.js stream
 library](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options).
 Stream piping is one of the advanced streaming features we mentioned
-earlier \-- it allows you to automatically send the output of one stream
+earlier --- it allows you to automatically send the output of one stream
 into another stream.
 
 The apm-nodejs-http-client does not *directly* use the stream's pipe
@@ -275,9 +275,11 @@ method. Instead [we
 use](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L457)
 a [library named pump](https://www.npmjs.com/package/pump)
 
-pump(stream, req, **function** () {\
-*// callback invoked when the streams end*\
+```
+pump(stream, req, function () {
+    // callback invoked when the streams ends
 })
+```
 
 The pump function will pipe one stream to another. Pump's special
 feature is if the destination-stream closes for any reason, **pump will
@@ -292,7 +294,7 @@ When the stream-chopper creates a new zlib stream it issues a stream
 event.
 
 The apm-nodejs-http-client's stream listener will hear this event and
-fire its callback -- which will create a new request starting the whole
+fire its callback --- which will create a new request starting the whole
 process over again.
 
 All this leaves one thing unanswered: What ends the HTTP request stream?
@@ -308,9 +310,9 @@ generic server timeout variable.
 
 Earlier we mentioned one feature of the stream-chopper was
 
-> *If the stream-chopper writes data to a stream passed a configured
+> If the stream-chopper writes data to a stream passed a configured
 > time limit, the stream-chopper will close and destroy the
-> destination-stream object, and then create a new destination-stream*
+> destination-stream object, and then create a new destination-stream
 
 The stream-chopper has [[a time
 limit]{.ul}](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L97)
@@ -320,8 +322,8 @@ sets this time limit. This means that, by default, every stream-chopper
 destination-stream will be kept open for 10 seconds.
 
 This *also* means that every request stream will be kept open for 10
-seconds. That's because of the pump library \-- **whenever** the
-destination-stream closes, the request stream will close as well.
+seconds. That's because of the pump library. The pump library ensures **whenever** the
+destination-stream closes that the request stream will close as well.
 
 ### Server Timeout
 

--- a/docs/internals/client-streams.md
+++ b/docs/internals/client-streams.md
@@ -1,0 +1,374 @@
+Node.js APM Agent HTTP Client Streams
+=====================================
+
+When the Elastic Node.js agent sends data to the
+[apm-nodejs-http-client](https://github.com/elastic/apm-nodejs-http-client),
+this starts a process where the data will pass through *three* Node.js
+stream objects before finally being piped into a HTTP(S) request stream
+(for four streams total). This request stream sends the data on the APM
+server
+
+```
+           Node.js Agent     
+                 ↓
+    [ apm-nodejs-http-client ] 
+                 ↓
+    [     stream-chopper     ]    
+                 ↓
+    [      zlib stream       ]
+                 ↓
+    [     request stream     ]
+                 ↓
+            APM Server    
+```
+
+The intent of this document is to describe the lifecycle of a piece of
+agent data from first being written to the client stream all the way to
+the point it's sent to the APM Server via a Node.js request object.
+
+What is a Stream?
+-----------------
+
+A stream is a Node.js object that allows a client-programmer to write
+data to an object. This allows the stream programmer to take
+programmatic action based on the data being written to the stream.
+Streams have many uses, but they're most commonly used to provide memory
+efficient data processing and transformation.
+
+Consider this simple program
+
+```javascript
+    const { Stream } = require('stream')
+    const strem = require('stream')
+
+    class MyStream extends Stream.Writable {
+      _write (chunk, encoding, callback) {
+        console.log('START: _write')
+        console.log(chunk.toString())
+        console.log(encoding)
+        console.log('END: _write')
+        callback()
+      }
+    }
+
+    const s = new MyStream
+    s.write('hello stream')
+```
+
+The MyStream class allows us to create a stream object which we can
+write data to. The MyStream object can take action whenever data is
+written to this stream.
+
+Streams can do way more than what this simple program does. If you want
+to learn more [the official
+docs](https://nodesource.com/blog/understanding-streams-in-nodejs/) and
+[this
+NodeSource](https://nodesource.com/blog/understanding-streams-in-nodejs/)
+article are good places to get started.
+
+For our purposes we'll discuss additional stream features as they come
+up.
+
+Elastic's Node.js APM Client Streams
+------------------------------------
+
+Let's look at our stream diagram again
+
+```
+           Node.js Agent     
+                 ↓
+    [ apm-nodejs-http-client ] 
+                 ↓
+    [     stream-chopper     ]    
+                 ↓
+    [      zlib stream       ]
+                 ↓
+    [     request stream     ]
+                 ↓
+            APM Server        
+```
+
+That's four distinct stream objects between the agent and the APM Server
+instance. There's the apm-nodejs-http-client itself, which is the
+Writable stream where data originates. There's a stream called the
+stream-chopper. There's a zlib stream that accepts uncompressed data and
+writes compressed data back out. Finally, there's a Node.js HTTP
+request, which is also a stream.
+
+Let's look at each stream object independently.
+
+### apm-nodejs-http-client
+
+Whenever the Elastic Agent wants to send a piece of data to APM Server,
+it will first call a method on the apm-nodejs-http-client object. You
+can see an example [of that
+here](https://github.com/elastic/apm-agent-nodejs/blob/3c2505b5f299381f09409500b4f0108dbb01ba38/lib/instrumentation/index.js#L241),
+with the agent calling the sendSpan method of the apm-nodejs-http-client
+object.
+
+```javascript
+      if (agent._transport) agent._transport.sendSpan(payload)
+```
+
+If you take a look at [the definition of
+sendSpan](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L348)
+we see that the apm-nodejs-http-client (Client below) will write to
+itself.
+
+```javascript
+    Client.prototype.sendSpan = function (span, cb) {
+      this._maybeCork()
+      return this.write({ span }, Client.encoding.SPAN, cb)
+    }
+```
+
+This apm-nodejs-http-client serves as an API/interface between the Agent
+and the APM Server, but it's also a stream object.
+
+When processing the data that's been written to it, the Client will
+write data to a second stream, known as the stream-chopper.
+
+### stream-chopper
+
+So what [is the
+stream-chopper](https://www.npmjs.com/package/stream-chopper)? It's
+another stream object with some extra behavior.
+
+The stream-chopper
+
+1.  Accepts data from a source stream
+
+2.  Creates a **new** destination-stream
+
+3.  Writes data to this new destination-stream
+
+4.  If the amount of data written reaches a threshold, the
+    stream-chopper will close and destroy the destination-stream object,
+    and then create a new destination-stream
+
+5.  If the stream-chopper writes data to a stream passed a configured
+    time limit, the stream-chopper will close and destroy the
+    destination-stream object, and then create a new destination-stream
+
+6.  Also, if the destination-stream is closed for any other reason, the
+    stream-chopper will create a new destination-stream
+
+7.  Whenever the stream-chopper creates a new destination-stream, it
+    emits a stream event
+
+So, if we consider a portion of our stream diagram
+
+```
+    [stream-chopper] -> [zlib stream] -> [request]
+```
+
+the following is a more accurate representation of what's going on
+
+```
+                     / ---> [zlib stream] -> [request]
+    [stream-chopper] -----> [zlib stream] -> [request]
+                     \ ---> [zlib stream] -> [request]
+
+```
+
+Over the lifetime of an agent process, the stream-chopper will be
+constantly creating new streams to write data to whenever something ends
+its destination-stream. However, the stream chopper should only ever
+have one destination-stream active at time.
+
+The apm-nodejs-http-client object instantiates the stream-chopper [in
+its
+constructor](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L95).
+The stream-chopper is a single instance object.
+
+```javascript
+    this._chopper = new StreamChopper({
+        size: this._conf.size,
+        time: this._conf.time,
+        type: StreamChopper.overflow,
+        transform () {
+          return zlib.createGzip()
+        }
+    }).on('stream', onStream(this, errorproxy))
+```   
+
+### zib stream
+
+The zlib stream is a destination-stream object created by the
+stream-chopper. The zlib stream is what's known as [a Transform
+stream](https://nodejs.org/api/stream.html#stream_class_stream_transform).
+It accepts data in one form (uncompressed), and will write data back out
+in another form (compressed via zlib)
+
+The stream-chopper creates a zlib destination-stream because we've told
+it to. When we configure the stream-chopper, we included a transform
+function.
+
+```javascript
+    this._chopper = new StreamChopper({
+        size: this._conf.size,
+        time: this._conf.time,
+        type: StreamChopper.overflow,
+        transform () {
+          return zlib.createGzip()
+        }
+    }).on('stream', onStream(this, errorproxy))
+```  
+
+By adding this transform function as an argument to the stream-chopper's
+constructor, this allows us to define a function that creates the
+stream-chopper's destination stream.
+
+### HTTP Request
+
+Whenever a stream-chopper object creates a new zlib destination-stream,
+the stream-chopper emits a stream event. When the client instantiates a
+stream-chopper object, it also [sets up a listener for this
+event](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L102)
+
+```javascript
+    // ...
+
+    }).on('stream', onStream(this, errorproxy))
+    
+    // ...
+    
+    function onStream (client, onerror) {
+      return function (stream, next) {    
+        //... stream listener ...
+      }
+    }
+
+    // ...
+```
+
+This listener is where we instantiate the HTTP request to the APM
+server. This request object is our our final stream
+
+```javascript
+    // `_transport` is either a `require('http')` or `require('https')`
+    const req = client._transport.request(client._conf.requestIntake, onResult(onerror))
+```
+
+Both the http and https modules in Node.js provide a low level
+streamable interfaces for making HTTP requests. The request object
+returned by this call to request is a stream object.
+
+Next, the listener function [will
+pipe](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options)
+the data from the zlib stream to the req stream. This means the
+compressed data that the zlib stream is writing will be written to the
+req stream. In other words -- the compressed data coming out of the zlib
+stream will be sent to the APM Server.
+
+Pump vs. Pipe
+-------------
+
+Stream piping is [a built-in feature of the Node.js stream
+library](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options).
+Stream piping is one of the advanced streaming features we mentioned
+earlier \-- it allows you to automatically send the output of one stream
+into another stream.
+
+The apm-nodejs-http-client does not *directly* use the stream's pipe
+method. Instead [we
+use](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L457)
+a [library named pump](https://www.npmjs.com/package/pump)
+
+pump(stream, req, **function** () {\
+*// callback invoked when the streams end*\
+})
+
+The pump function will pipe one stream to another. Pump's special
+feature is if the destination-stream closes for any reason, **pump will
+also close and automatically destroy the source stream**.
+
+This means when the req to the APM Server finishes, pump will also
+end/close/destroy the zlib stream created by the stream-chopper.
+
+When this happens, the stream-chopper will create a new zlib stream.
+
+When the stream-chopper creates a new zlib stream it issues a stream
+event.
+
+The apm-nodejs-http-client's stream listener will hear this event and
+fire its callback -- which will create a new request starting the whole
+process over again.
+
+All this leaves one thing unanswered: What ends the HTTP request stream?
+
+Request Ending
+--------------
+
+There's two ways an HTTP request to the APM server might naturally end.
+The first is the stream-chopper's stream timeout. The second is via the
+generic server timeout variable.
+
+### Stream Timeout/Closing
+
+Earlier we mentioned one feature of the stream-chopper was
+
+> *If the stream-chopper writes data to a stream passed a configured
+> time limit, the stream-chopper will close and destroy the
+> destination-stream object, and then create a new destination-stream*
+
+The stream-chopper has [[a time
+limit]{.ul}](https://github.com/elastic/apm-nodejs-http-client/blob/7f352b2181533435eee11d9da4d41a15ac607851/index.js#L97)
+on how long it will write to any destination-stream. In the agent, the
+[`apiRequestTime`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#api-request-time)
+sets this time limit. This means that, by default, every stream-chopper
+destination-stream will be kept open for 10 seconds.
+
+This *also* means that every request stream will be kept open for 10
+seconds. That's because of the pump library \-- **whenever** the
+destination-stream closes, the request stream will close as well.
+
+### Server Timeout
+
+The agent also has a
+[`serverTimeout`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#server-timeout)
+configuration variable. This setting offers a generic request timeout for the client.
+
+This configuration value will be converted into milliseconds and [passed on to the request](https://github.com/elastic/apm-nodejs-http-client/blob/cac3e9f47d7fd4e9c3894f52e5ed17b04e58eec1/index.js#L452) object's 
+[`setTimeout`](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback) method.
+
+```javascript
+    if (Number.isFinite(client._conf.serverTimeout)) {
+      req.setTimeout(client._conf.serverTimeout, function () {
+        req.destroy(new Error(`APM Server response timeout (${client._conf.serverTimeout}ms)`))
+      })
+    }
+```
+
+One interesting thing to note: With an agent's default configuration
+values, this second
+[`serverTimeout`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#server-timeout)
+will rarely be reached since its default (of 30 seconds) is less than
+the
+[`apiRequestTime`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#api-request-time)
+default (of 10 seconds).
+
+The
+[`serverTimeout`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#server-timeout)
+value exists to handle cases where both the zlib destination-stream and
+the request stream have ended, but the client is still waiting for APM
+Server to respond to and end the HTTP request. Under ideal conditions
+APM Server will respond and end the HTTP request right away, but since
+we can't rely on the behavior of APM Server in non-ideal conditions, the
+[`serverTimeout`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#server-timeout)
+configuration value serves as an escape hatch to ensure the HTTP request
+is not held open potentially forever. Without this escape hatch, an
+overwhelmed APM Server might result in a lot of active HTTP requests
+waiting to finish. This in turn means that the Node.js HTTP Agent keeps
+opening new TCP sockets to accommodate new HTTP requests, instead of
+reusing the existing open TCP sockets - essentially leaking memory and
+resources.
+
+In practice this means this
+[`serverTimeout`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#server-timeout)
+value should always be configured to a value that's larger than the
+[`apiRequestTime`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#api-request-time)
+value. With a value less than
+[`apiRequestTime`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#api-request-time)
+the client will destroy the HTTP request stream before it finishes
+sending its data.

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -1,8 +1,8 @@
 # Elastic APM Node.js HTTP Client Internals
 
-The following documents describe some of the APIs and architecture that implement agent fields internally.  These features are not considered a public API -- they are implementation details that may change and shift over time irrespective of the client's current semantic version.    
+The following documents describe some of the private APIs and architecture used in this client.  The code discussed here is not considered a public API.  These routines are  implementation details that may change and shift over time irrespective of the client's current semantic version.    
 
-The primary intent of these documents is to give developers and engineers who want to work an agent features a map of the territory.  
+The primary intent of these documents is to give developers and engineers who want to work on features a map of the territory.  
 
 - [Client Streams](./client-streams.md)
 - [Client Streams and Corking](./stream-corking.md)

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -1,0 +1,10 @@
+# Elastic APM Node.js HTTP Client Internals
+
+The following documents describe some of the APIs and architecture that implement agent fields internally.  These features are not considered a public API -- they are implementation details that may change and shift over time irrespective of the client's current semantic version.    
+
+The primary intent of these documents is to give developers and engineers who want to work an agent features a map of the territory.  
+
+- [Client Streams](./client-streams.md)
+- [Client Streams and Corking](./stream-corking.md)
+
+Don't see what you're looking for?  [Let us know](https://github.com/elastic/apm-nodejs-http-client/issues) which system you're trying to understand and what sort of questions you have. 

--- a/docs/internals/stream-corking.md
+++ b/docs/internals/stream-corking.md
@@ -1,19 +1,19 @@
 # Stream Corking
 
-As discussed elsewhere, the Elastic Node.js Agent's HTTP Client is a writable stream object.  One advanced streaming feature the client uses [is Node.js stream corking](https://nodejs.org/api/stream.html#stream_writable_cork).  
+As discussed elsewhere, the Elastic Node.js Agent's HTTP Client is a writable stream object.  One advanced streaming feature the client uses [is Node.js stream corking](https://nodejs.org/api/stream.html#stream_writable_cork).
 
-We use stream corking to solve two independant challenges.  The first is to delay writes to the downstream stream chopper object until the client is 100% ready to send data.  The second is to prevent what Node.js calls "head-of-line blocking" issues, when the writing of individual objects downstream can creating blocking code situations.  
+We use stream corking to solve two independent challenges.  The first is to delay writes to the downstream stream chopper object until the client is 100% ready to send data.  The second is to prevent what Node.js calls "head-of-line blocking" issues, when the writing of individual objects downstream can creating blocking code situations.
 
-This document will describe both scenarios, as well as provide a basic primer on Node.js stream corking. 
+This document will describe both scenarios, as well as provide a basic primer on Node.js stream corking.
 
 ## Stream Corking
 
-One way of looking at a Node.js Writable stream object is as an API that 
+One way of looking at a Node.js Writable stream object is as an API that
 
 1. Allows a client programmer to _write_ data to an object
 2. Allows a stream programmer to take programatic action when that data is written
 
-If we consider streams from that point of view, stream corking will _delay_ the programatic action that happens when data's written to a stream.  It will delay this action until the stream is uncorked.  
+If we consider streams from that point of view, stream corking will _delay_ the programatic action that happens when data's written to a stream.  It will delay this action until the stream is uncorked.
 
 ### Sample Program
 
@@ -46,10 +46,10 @@ Consider this sample program.
     syncLog('done with our for loop')
 ```
 
-    
+
 Here we have a simple _Hello World_ stream object.  Run it, and we see data logged via the `_write` method of the stream object.
 
-    
+
     % node sample.js
     starting our for loop
     on loop number 0
@@ -64,7 +64,7 @@ Here we have a simple _Hello World_ stream object.  Run it, and we see data logg
     on loop number 9
     done with our for loop
 
-However -- if we _cork_ that stream before writing and then _uncork_ after our for loop.
+However --- if we _cork_ that stream before writing and then _uncork_ after our for loop.
 
     const fs = require('fs')
     const { Stream } = require('stream')
@@ -95,8 +95,8 @@ However -- if we _cork_ that stream before writing and then _uncork_ after our f
 
     // NEW: un-corking the stream
     s.uncork()
-    
-and run the program 
+
+and run the program
 
     % node /tmp/sample.js
     starting our for loop
@@ -114,27 +114,27 @@ and run the program
 
 We can see that Node.js does not call `_write` until after the stream's been uncorked.
 
-### _writev method     
-                         
+### _writev method
+
 The full benefit of stream corking isn't apparent until we consider what happens when a stream is uncorked.  When we cork a stream, data starts to accumulate inside that stream object.  When we uncork that stream, there will be _multiple_ objects to write out.  In our example above, this meant ten individual calls to the `_write` method.
 
-Node.js's stream APIs include a feature that allows the stream programmer to take programatic action on _all_ the buffered data in a stream at once.  If a stream object implements the `_writev` method, Node.js will call this method _instead_ of calling `_write` _when there's data backed up in a stream_.  Node.js will also pass `_writev` an array of _all_ the data. 
+The Node.js stream APIs include a feature that allows the stream programmer to take programatic action on _all_ the buffered data in a stream at once.  If a stream object implements the `_writev` method, Node.js will call this method _instead_ of calling `_write` _when there's data backed up in a stream_.  Node.js will also pass `_writev` an array of _all_ the data.
 
-The `_writev` method allows a stream programmer to write more efficient stream objects.  First, a single call to `_writev` vs. individual calls to `write` is fewer method calls overall -- which can add up for a busy stream.  Additionally, `_writev` allows a stream programmer to act on large sets of data _all at once_.  Batching large sets of data like this can often lead to better performance -- although the specifics will depend on the code an individual stream programmer writes.  
+The `_writev` method allows a stream programmer to write more efficient stream objects.  First, a single call to `_writev` (vs. individual calls to `write`) is fewer method calls overall --- which can add up for a busy stream.  Additionally, `_writev` allows a stream programmer to act on large sets of data _all at once_.  Batching large sets of data like this can often lead to better performance --- although the specifics will depend on the code an individual stream programmer writes.
 
-The main tradeoff of `_writev` is in code complexity.  A stream can implement `_write`, `_writev`, or both.  It's up to the client programmer to ensure each of these methods behaves is a similar/reasonable way.  
+The main tradeoff of `_writev` is in code complexity.  A stream can implement `_write`, `_writev`, or both.  It's up to the client programmer to ensure each of these methods behaves is a similar/reasonable way.
 
-This article won't get too into _how_ the client object uses `_write` and `_writev` -- we're more inserted in how stream corking delays calls to these methods. 
-                      
+This article won't get too into _how_ the client object uses `_write` and `_writev` --- we're more inserted in how stream corking delays calls to these methods.
+
 ## Stream Corking and Agent Initialization
 
-To understand to first use case of stream corking in the client we need to understand how the client is instantiated, as well as the understand the metadata that the  agent/client needs to collect before it can send data to APM Server.
+To understand to first use case of stream corking in the client we need to understand how the client is instantiated, as well as understand the metadata that the  agent/client needs to collect before it can send data to APM Server.
 
-The APM Server APIs requires that each request begins with a metadata object.  This metadata contains information about the running agent instance.  Collecting some of this data, like the service name, is as simple as inspecting the agent's configuration.  Colling data other data, however, requires us to query the local server environment in an asynchronous fashion. 
+The APM Server APIs requires that each request begins with a metadata object.  This metadata contains information about the running agent instance.  Collecting some of this data, like the service name, is as simple as inspecting the agent's configuration.  Collecting data other data, however, requires us to query the local server environment in an asynchronous fashion.
 
-This means the client can't send data to APM Server right away.  The client currently uses stream corking to buffer data in the client until these asynchronous network requests are finished. 
+This means the client can't send data to APM Server right away.  The client currently uses stream corking to buffer data in the client until these asynchronous network requests are finished.
 
-Specifically, in the client's constructor function, [we `cork` the stream](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L100), make our asynchronous network request [via the `_fetchAndEncodeMetadata` function](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L101), and then [uncork the stream once this request has finished](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L106). 
+Specifically, in the client's constructor function, [we `cork` the stream](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L100), make our asynchronous network request [via the `_fetchAndEncodeMetadata` function](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L101), and then [uncork the stream once this request has finished](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L106).
 
 ```javascript
   this.cork()
@@ -158,10 +158,10 @@ The effectively blocks data from being written to the stream chopper until these
 
 ## Data Buffering
 
-The second way we use corking is to buffer our stream writes. Data is never immediately written to the stream chopper object.  Instead, the client stream will repeatedly 
+The second way we use corking is to buffer our stream writes. Data is never immediately written to the stream chopper object.  Instead, the client stream will repeatedly
 
 1. Cork itself
-2. After a _period of time or activity_, uncork itself. 
+2. After a _period of time or activity_, uncork itself.
 3. (This triggers a data write to the stream chopper)
 4. `GOTO 1`
 
@@ -169,16 +169,16 @@ There are two agent configuration values the control the _period of time or acti
 
     bufferWindowTime
     bufferWindowSize
-    
+
 The first, `bufferWindowTime`, allows us to configure a time limit for how often the client stream will uncork itself.  The default is 20 milliseconds.
 
-The second, `bufferWindowSize`, allows us to configure a _how many objects_ the client stream will hold on to before uncorking itself.  The default is 50 objects.  
+The second, `bufferWindowSize`, allows us to configure a _how many objects_ the client stream will hold on to before uncorking itself.  The default is 50 objects.
 
-The `bufferWindowSize` configuration will superseed the `bufferWindowTime` configuration.  In other words, with a default configuration, if the stream receives 51 objects in 10 milliseconds, the stream will uncork itself and the timer will be reset to 20 milliseconds.
+The `bufferWindowSize` configuration will supersede the `bufferWindowTime` configuration.  In other words, with a default configuration, if the stream receives 51 objects in 10 milliseconds, the stream will uncork itself and the timer will be reset to 20 milliseconds.
 
 ## Detailed Corking Logic
-    
-The Elastic HTTP Client offers an API for sending data to APM Server.  Specifically, there are four methods -- `sendSpan`, `sendTransaction`, `sendError`, and `sendMetricSet`.
+
+The Elastic HTTP Client offers an API for sending data to APM Server.  Specifically, there are four methods --- `sendSpan`, `sendTransaction`, `sendError`, and `sendMetricSet`.
 
 The implementation of these methods [looks like this](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L391) .
 
@@ -201,13 +201,14 @@ Client.prototype.sendError = function (error, cb) {
 Client.prototype.sendMetricSet = function (metricset, cb) {
   this._maybeCork()
   return this.write({ metricset }, Client.encoding.METRICSET, cb)
-}```
+}
+```
 
-Prior to writing the span, transaction, error, or metricset data to itself, the HTTP client calls its `_maybeCork` method.  
+Prior to writing the span, transaction, error, or metricset data to itself, the HTTP client calls its `_maybeCork` method.
 
-If the stream is _not_ currently corked, the `_maybeCork` method will [cork the stream](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L333), and [create a timer with a callback](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L338) that will uncork the stream.  
+If the stream is _not_ currently corked, the `_maybeCork` method will [cork the stream](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L333), and [create a timer with a callback](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L338) that will uncork the stream.
 
-```javascript    
+```javascript
     Client.prototype._maybeCork = function () {
       if (!this._writableState.corked && this._conf.bufferWindowTime !== -1) {
         this.cork()
@@ -225,7 +226,7 @@ If the stream is _not_ currently corked, the `_maybeCork` method will [cork the 
         this._maybeUncork()
       }
     }
-```    
+```
 
 If the stream _is_ currently corked _and_ the number of objects written to the stream has reached the threshold set in the `bufferWindowSize` configuration, then we will uncork the stream via a call to `_maybeUncork`.
 
@@ -247,7 +248,7 @@ Client.prototype._maybeUncork = function () {
 }
 ```
 
-There's two things worth noting here.  The first -- uncorking the stream also means clearing the previously set cork timeout, effectively restting the cork timer. 
+There's two things worth noting here.  The first --- uncorking the stream also means clearing the previously set cork timeout, effectively resetting the cork timer.
 
-The second thing worth noting is that the `_maybeUncork` method does not uncork data immediately. Instead it schedules the uncorking via a `nextTick` callback.  By delaying the call to `uncork` this gives the current call to `write` a chance to add its data to the stream _before_ the stream is uncorked.  The tradeoff for this benefit is some potential for _interesting_ timing issues if other code has scheduled callbacks via `nextTick` in the current asynchronous context and those callbacks run instrumented code. 
+The second thing worth noting is that the `_maybeUncork` method does not uncork data immediately. Instead it schedules the uncorking via a `nextTick` callback.  By delaying the call to `uncork` this gives the current call to `write` a chance to add its data to the stream _before_ the stream is uncorked.  The tradeoff for this benefit is some potential for _interesting_ timing issues if other code has scheduled callbacks via `nextTick` in the current asynchronous context and those callbacks run instrumented code.
 

--- a/docs/internals/stream-corking.md
+++ b/docs/internals/stream-corking.md
@@ -4,30 +4,115 @@ As discussed elsewhere, the Elastic Node.js Agent's HTTP Client is a writable st
 
 We use stream corking to solve two independant challenges.  The first is to delay writes to the downstream stream chopper object until the client is 100% ready to send data.  The second is to prevent what Node.js calls "head-of-line blocking" issues, when the writing of individual objects downstream can creating blocking code situations.  
 
-This document will describe both scenarios, as well as provide a basic primer on Node.js stream corking. You'll get the most out of this document if you've read the [...](...) docs first. 
+This document will describe both scenarios, as well as provide a basic primer on Node.js stream corking. 
 
 ## Stream Corking
 
-As we discussing last time, one way of looking at a Node.js Writable stream object is as an API that 
+One way of looking at a Node.js Writable stream object is as an API that 
 
 1. Allows a client programmer to _write_ data to an object
 2. Allows a stream programmer to take programatic action when that data is written
 
-If we consider streams from that point of view, stream cork will _delay_ the programatic action that happens when data's written to a stream.  It will delay this action until the stream is uncorked.  
+If we consider streams from that point of view, stream corking will _delay_ the programatic action that happens when data's written to a stream.  It will delay this action until the stream is uncorked.  
 
 ### Sample Program
 
 Consider this sample program.
 
-    //...
+```javascript
+    // File: sample.js
+    const fs = require('fs')
+    const { Stream } = require('stream')
+
+    // a non-async logger function to make our
+    // order of operations more objects
+    function syncLog(message) {
+      fs.writeSync(process.stdout.fd, message)
+      fs.writeSync(process.stdout.fd, "\n")
+    }
+
+    class MyStream extends Stream.Writable {
+      _write (chunk, encoding, callback) {
+        syncLog(chunk.toString())
+        callback()
+      }
+    }
+
+    const s = new MyStream
+    syncLog('starting our for loop')
+    for(let i=0;i<10;i++) {
+      s.write(`on loop number ${i}`)
+    }
+    syncLog('done with our for loop')
+```
+
     
 Here we have a simple _Hello World_ stream object.  Run it, and we see data logged via the `_write` method of the stream object.
 
-However -- if we _cork_ that stream.
-
-    //...     
     
-and run the program, no data is written until we call uncork.
+    % node sample.js
+    starting our for loop
+    on loop number 0
+    on loop number 1
+    on loop number 2
+    on loop number 3
+    on loop number 4
+    on loop number 5
+    on loop number 6
+    on loop number 7
+    on loop number 8
+    on loop number 9
+    done with our for loop
+
+However -- if we _cork_ that stream before writing and then _uncork_ after our for loop.
+
+    const fs = require('fs')
+    const { Stream } = require('stream')
+
+    // a non-async logger function to make our
+    // order of operations more objects
+    function syncLog(message) {
+      fs.writeSync(process.stdout.fd, message)
+      fs.writeSync(process.stdout.fd, "\n")
+    }
+
+    class MyStream extends Stream.Writable {
+      _write (chunk, encoding, callback) {
+        syncLog(chunk.toString())
+        callback()
+      }
+    }
+
+    const s = new MyStream
+
+    // NEW: corking the stream
+    s.cork()
+    syncLog('starting our for loop')
+    for(let i=0;i<10;i++) {
+      s.write(`on loop number ${i}`)
+    }
+    syncLog('done with our for loop')
+
+    // NEW: un-corking the stream
+    s.uncork()
+    
+and run the program 
+
+    % node /tmp/sample.js
+    starting our for loop
+    done with our for loop
+    on loop number 0
+    on loop number 1
+    on loop number 2
+    on loop number 3
+    on loop number 4
+    on loop number 5
+    on loop number 6
+    on loop number 7
+    on loop number 8
+    on loop number 9
+
+We can see that Node.js does not call `_write` until after the stream's been uncorked.
 
 ### _writev method     
                          
@@ -45,32 +130,38 @@ This article won't get too into _how_ the client object uses `_write` and `_writ
 
 To understand to first use case of stream corking in the client we need to understand how the client is instantiated, as well as the understand the metadata that the  agent/client needs to collect before it can send data to APM Server.
 
-The APM Server APIs requires that each request begins with a metadata object.  This metadata contains information about the running agent instance.  Collecting some of this data, like `...` is as simple as inspecting the agent's configuration.  Colling data other data, however, requires us to query the local server environment in an asynchronous fashion. 
+The APM Server APIs requires that each request begins with a metadata object.  This metadata contains information about the running agent instance.  Collecting some of this data, like the service name, is as simple as inspecting the agent's configuration.  Colling data other data, however, requires us to query the local server environment in an asynchronous fashion. 
 
 This means the client can't send data to APM Server right away.  The client currently uses stream corking to buffer data in the client until these asynchronous network requests are finished. 
 
-Specifically, in the client's constructor function, [we `cork` the stream](...), 
+Specifically, in the client's constructor function, [we `cork` the stream](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L100), make our asynchronous network request [via the `_fetchAndEncodeMetadata` function](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L101), and then [uncork the stream once this request has finished](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L106). 
 
 ```javascript
-//...
+  this.cork()
+  this._fetchAndEncodeMetadata(() => {
+    // _fetchAndEncodeMetadata will have set/memoized the encoded
+    // metadata to the _encodedMetadata property.
+
+    // this uncork reverse the .cork call in the constructor (above)
+    this.uncork()
+
+    // the `cloud-metadata` event allows listeners to know when the
+    // agent has finished fetching and encoding its metadata for the
+    // first time
+    this.emit('cloud-metadata', this._encodedMetadata)
+  })
 ```
 
-make our asynchronous network request via the `...` function.
+ We also [_refuse_ to uncork the stream](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L350) until this metadata is present in the `_encodedMetadata` property.
 
-```javascript
-//...
-```
-
-and then uncork the stream once this request has finished.  We also _refuse_ to uncork the stream until this metadata is present in the `...` property.
-
-The effectively blocks data from being written to the stream chopper until these network requests finish.  Once the `...` property is set, this specific instance of stream corking will not be invoked again.
+The effectively blocks data from being written to the stream chopper until these network requests finish.  Once the `_encodedMetadata` property is set, this specific instance of stream corking will not be invoked again.
 
 ## Data Buffering
 
 The second way we use corking is to buffer our stream writes. Data is never immediately written to the stream chopper object.  Instead, the client stream will repeatedly 
 
 1. Cork itself
-2. After a period of time or activity, uncork itself. 
+2. After a _period of time or activity_, uncork itself. 
 3. (This triggers a data write to the stream chopper)
 4. `GOTO 1`
 
@@ -89,7 +180,7 @@ The `bufferWindowSize` configuration will superseed the `bufferWindowTime` confi
     
 The Elastic HTTP Client offers an API for sending data to APM Server.  Specifically, there are four methods -- `sendSpan`, `sendTransaction`, `sendError`, and `sendMetricSet`.
 
-The implementation of these methods looks like this.
+The implementation of these methods [looks like this](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L391) .
 
 ```javascript
 Client.prototype.sendSpan = function (span, cb) {
@@ -112,9 +203,9 @@ Client.prototype.sendMetricSet = function (metricset, cb) {
   return this.write({ metricset }, Client.encoding.METRICSET, cb)
 }```
 
-Prior to writing the span, transaction, error, or metric set data to itself, the HTTP client calls its `_maybeCork` method.  
+Prior to writing the span, transaction, error, or metricset data to itself, the HTTP client calls its `_maybeCork` method.  
 
-If the stream is _not_ currently corked, the `_maybeCork` method will [cork the stream](...), and [create a timer with a callback](...) that will uncork the stream.  
+If the stream is _not_ currently corked, the `_maybeCork` method will [cork the stream](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L333), and [create a timer with a callback](https://github.com/elastic/apm-nodejs-http-client/blob/b992ef5a0a1eba3a2690cd275acb88938174c8fa/index.js#L338) that will uncork the stream.  
 
 ```javascript    
     Client.prototype._maybeCork = function () {
@@ -158,5 +249,5 @@ Client.prototype._maybeUncork = function () {
 
 There's two things worth noting here.  The first -- uncorking the stream also means clearing the previously set cork timeout, effectively restting the cork timer. 
 
-The second thing worth noting is that the `_maybeUncork` method does not uncork data immediately. Instead it schedules the uncorking via a `nextTick` callback.  By delaying the call to `uncork` this gives the current call to `write` a chance to add its data to the stream _before_ the stream is uncorked.  The tradeoff for this benefit is  some potential for _interesting_ timing issues if other code has scheduled callbacks via `nextTick` in the current asynchronous context and those callbacks run instrumented code. 
+The second thing worth noting is that the `_maybeUncork` method does not uncork data immediately. Instead it schedules the uncorking via a `nextTick` callback.  By delaying the call to `uncork` this gives the current call to `write` a chance to add its data to the stream _before_ the stream is uncorked.  The tradeoff for this benefit is some potential for _interesting_ timing issues if other code has scheduled callbacks via `nextTick` in the current asynchronous context and those callbacks run instrumented code. 
 

--- a/docs/internals/stream-corking.md
+++ b/docs/internals/stream-corking.md
@@ -1,0 +1,162 @@
+# Stream Corking
+
+As discussed elsewhere, the Elastic Node.js Agent's HTTP Client is a writable stream object.  One advanced streaming feature the client uses [is Node.js stream corking](https://nodejs.org/api/stream.html#stream_writable_cork).  
+
+We use stream corking to solve two independant challenges.  The first is to delay writes to the downstream stream chopper object until the client is 100% ready to send data.  The second is to prevent what Node.js calls "head-of-line blocking" issues, when the writing of individual objects downstream can creating blocking code situations.  
+
+This document will describe both scenarios, as well as provide a basic primer on Node.js stream corking. You'll get the most out of this document if you've read the [...](...) docs first. 
+
+## Stream Corking
+
+As we discussing last time, one way of looking at a Node.js Writable stream object is as an API that 
+
+1. Allows a client programmer to _write_ data to an object
+2. Allows a stream programmer to take programatic action when that data is written
+
+If we consider streams from that point of view, stream cork will _delay_ the programatic action that happens when data's written to a stream.  It will delay this action until the stream is uncorked.  
+
+### Sample Program
+
+Consider this sample program.
+
+    //...
+    
+Here we have a simple _Hello World_ stream object.  Run it, and we see data logged via the `_write` method of the stream object.
+
+However -- if we _cork_ that stream.
+
+    //...     
+    
+and run the program, no data is written until we call uncork.
+
+### _writev method     
+                         
+The full benefit of stream corking isn't apparent until we consider what happens when a stream is uncorked.  When we cork a stream, data starts to accumulate inside that stream object.  When we uncork that stream, there will be _multiple_ objects to write out.  In our example above, this meant ten individual calls to the `_write` method.
+
+Node.js's stream APIs include a feature that allows the stream programmer to take programatic action on _all_ the buffered data in a stream at once.  If a stream object implements the `_writev` method, Node.js will call this method _instead_ of calling `_write` _when there's data backed up in a stream_.  Node.js will also pass `_writev` an array of _all_ the data. 
+
+The `_writev` method allows a stream programmer to write more efficient stream objects.  First, a single call to `_writev` vs. individual calls to `write` is fewer method calls overall -- which can add up for a busy stream.  Additionally, `_writev` allows a stream programmer to act on large sets of data _all at once_.  Batching large sets of data like this can often lead to better performance -- although the specifics will depend on the code an individual stream programmer writes.  
+
+The main tradeoff of `_writev` is in code complexity.  A stream can implement `_write`, `_writev`, or both.  It's up to the client programmer to ensure each of these methods behaves is a similar/reasonable way.  
+
+This article won't get too into _how_ the client object uses `_write` and `_writev` -- we're more inserted in how stream corking delays calls to these methods. 
+                      
+## Stream Corking and Agent Initialization
+
+To understand to first use case of stream corking in the client we need to understand how the client is instantiated, as well as the understand the metadata that the  agent/client needs to collect before it can send data to APM Server.
+
+The APM Server APIs requires that each request begins with a metadata object.  This metadata contains information about the running agent instance.  Collecting some of this data, like `...` is as simple as inspecting the agent's configuration.  Colling data other data, however, requires us to query the local server environment in an asynchronous fashion. 
+
+This means the client can't send data to APM Server right away.  The client currently uses stream corking to buffer data in the client until these asynchronous network requests are finished. 
+
+Specifically, in the client's constructor function, [we `cork` the stream](...), 
+
+```javascript
+//...
+```
+
+make our asynchronous network request via the `...` function.
+
+```javascript
+//...
+```
+
+and then uncork the stream once this request has finished.  We also _refuse_ to uncork the stream until this metadata is present in the `...` property.
+
+The effectively blocks data from being written to the stream chopper until these network requests finish.  Once the `...` property is set, this specific instance of stream corking will not be invoked again.
+
+## Data Buffering
+
+The second way we use corking is to buffer our stream writes. Data is never immediately written to the stream chopper object.  Instead, the client stream will repeatedly 
+
+1. Cork itself
+2. After a period of time or activity, uncork itself. 
+3. (This triggers a data write to the stream chopper)
+4. `GOTO 1`
+
+There are two agent configuration values the control the _period of time or activity_.
+
+    bufferWindowTime
+    bufferWindowSize
+    
+The first, `bufferWindowTime`, allows us to configure a time limit for how often the client stream will uncork itself.  The default is 20 milliseconds.
+
+The second, `bufferWindowSize`, allows us to configure a _how many objects_ the client stream will hold on to before uncorking itself.  The default is 50 objects.  
+
+The `bufferWindowSize` configuration will superseed the `bufferWindowTime` configuration.  In other words, with a default configuration, if the stream receives 51 objects in 10 milliseconds, the stream will uncork itself and the timer will be reset to 20 milliseconds.
+
+## Detailed Corking Logic
+    
+The Elastic HTTP Client offers an API for sending data to APM Server.  Specifically, there are four methods -- `sendSpan`, `sendTransaction`, `sendError`, and `sendMetricSet`.
+
+The implementation of these methods looks like this.
+
+```javascript
+Client.prototype.sendSpan = function (span, cb) {
+  this._maybeCork()
+  return this.write({ span }, Client.encoding.SPAN, cb)
+}
+
+Client.prototype.sendTransaction = function (transaction, cb) {
+  this._maybeCork()
+  return this.write({ transaction }, Client.encoding.TRANSACTION, cb)
+}
+
+Client.prototype.sendError = function (error, cb) {
+  this._maybeCork()
+  return this.write({ error }, Client.encoding.ERROR, cb)
+}
+
+Client.prototype.sendMetricSet = function (metricset, cb) {
+  this._maybeCork()
+  return this.write({ metricset }, Client.encoding.METRICSET, cb)
+}```
+
+Prior to writing the span, transaction, error, or metric set data to itself, the HTTP client calls its `_maybeCork` method.  
+
+If the stream is _not_ currently corked, the `_maybeCork` method will [cork the stream](...), and [create a timer with a callback](...) that will uncork the stream.  
+
+```javascript    
+    Client.prototype._maybeCork = function () {
+      if (!this._writableState.corked && this._conf.bufferWindowTime !== -1) {
+        this.cork()
+        if (this._corkTimer && this._corkTimer.refresh) {
+          // the refresh function was added in Node 10.2.0
+          // if refresh is avaiable and the timer object is still
+          // here, just reuse it rather than create a new timer
+          this._corkTimer.refresh()
+        } else {
+          this._corkTimer = setTimeout(() => {
+            this.uncork()
+          }, this._conf.bufferWindowTime)
+        }
+      } else if (this._writableState.length >= this._conf.bufferWindowSize) {
+        this._maybeUncork()
+      }
+    }
+```    
+
+If the stream _is_ currently corked _and_ the number of objects written to the stream has reached the threshold set in the `bufferWindowSize` configuration, then we will uncork the stream via a call to `_maybeUncork`.
+
+```
+Client.prototype._maybeUncork = function () {
+  if (this._writableState.corked) {
+    // Wait till next tick, so that the current write that triggered the call
+    // to `_maybeUncork` have time to be added to the queue. If we didn't do
+    // this, that last write would trigger a single call to `_write`.
+    process.nextTick(() => {
+      if (this.destroyed === false) this.uncork()
+    })
+
+    if (this._corkTimer) {
+      clearTimeout(this._corkTimer)
+      this._corkTimer = null
+    }
+  }
+}
+```
+
+There's two things worth noting here.  The first -- uncorking the stream also means clearing the previously set cork timeout, effectively restting the cork timer. 
+
+The second thing worth noting is that the `_maybeUncork` method does not uncork data immediately. Instead it schedules the uncorking via a `nextTick` callback.  By delaying the call to `uncork` this gives the current call to `write` a chance to add its data to the stream _before_ the stream is uncorked.  The tradeoff for this benefit is  some potential for _interesting_ timing issues if other code has scheduled callbacks via `nextTick` in the current asynchronous context and those callbacks run instrumented code. 
+


### PR DESCRIPTION
This PR creates a `docs` folder for this repo and adds a few initial documents describing how the HTTP client uses Node's underlying stream APIs to receive data and send it on to the APM server.  Created at the request @felixbarny and my own internal "how does this even work demon dogs. 