### PR TITLE
fix: possible write after .destroy() if destroyed before metadata fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,8 +102,9 @@ function Client (opts) {
     // _fetchAndEncodeMetadata will have set/memoized the encoded
     // metadata to the _encodedMetadata property.
 
-    // this uncork reverse the .cork call in the constructor (above)
-    this.uncork()
+    // This reverses the cork() call in the constructor above. "Maybe" uncork,
+    // in case the client has been destroyed before this callback is called.
+    this._maybeUncork()
 
     // the `cloud-metadata` event allows listeners to know when the
     // agent has finished fetching and encoding its metadata for the

--- a/test/basic.js
+++ b/test/basic.js
@@ -254,13 +254,20 @@ test('client.flush(callback) - with queued request', function (t) {
       }
     })
   }).client({ bufferWindowTime: -1 }, function (client) {
+    // Cloud metadata fetching means that a write (via `client.sendSpan()` or
+    // similar) does *not* mean an immediately active outgoing request until
+    // *some time after* cloud metadata is fetched. That "some time after" is
+    // after (a) the "cloud-metadata" event, plus (b) the `nextTick()` in
+    // `_maybeUncork()` before calling `uncork()`.
     client.on('cloud-metadata', function () {
-      client.sendSpan({ req: 1 })
-      client.flush()
-      client.sendSpan({ req: 2 })
-      t.equal(client._active, true, 'an outgoing HTTP request should be active')
-      client.flush(function () {
-        t.equal(client._active, false, 'the outgoing HTTP request should be done')
+      process.nextTick(function () {
+        client.sendSpan({ req: 1 })
+        client.flush()
+        client.sendSpan({ req: 2 })
+        t.equal(client._active, true, 'an outgoing HTTP request should be active')
+        client.flush(function () {
+          t.equal(client._active, false, 'the outgoing HTTP request should be done')
+        })
       })
     })
   })

--- a/test/basic.js
+++ b/test/basic.js
@@ -211,12 +211,19 @@ test('client.flush(callback) - with active request', function (t) {
       t.end()
     })
   }).client({ bufferWindowTime: -1 }, function (client) {
+    // Cloud metadata fetching means that a write (via `client.sendSpan()` or
+    // similar) does *not* mean an immediately active outgoing request until
+    // *some time after* cloud metadata is fetched. That "some time after" is
+    // after (a) the "cloud-metadata" event, plus (b) the `nextTick()` in
+    // `_maybeUncork()` before calling `uncork()`.
     client.on('cloud-metadata', function () {
-      t.equal(client._active, false, 'no outgoing HTTP request to begin with')
-      client.sendSpan({ foo: 42 })
-      t.equal(client._active, true, 'an outgoing HTTP request should be active')
-      client.flush(function () {
-        t.equal(client._active, false, 'the outgoing HTTP request should be done')
+      process.nextTick(function () {
+        t.equal(client._active, false, 'no outgoing HTTP request to begin with')
+        client.sendSpan({ foo: 42 })
+        t.equal(client._active, true, 'an outgoing HTTP request should be active')
+        client.flush(function () {
+          t.equal(client._active, false, 'the outgoing HTTP request should be done')
+        })
       })
     })
   })


### PR DESCRIPTION
If the client was .destroy()d before cloud metadata fetching was
complete then the unconditional `.uncork()` in the fetching callback
could result in writing to the stream. Using `.maybeUncork()` uses the
explicit guard to not uncork if the stream is destroyed.

## the problem

In apm-agent-nodejs tests I was observing this error in the apm-server client
at the end of some tests:

```
APM Server transport error: Error: Cannot call write after a stream was destroyed
    at doWrite (/Users/trentm/el/apm-agent-nodejs2/node_modules/readable-stream/lib/_stream_writable.js:409:38)
    at clearBuffer (/Users/trentm/el/apm-agent-nodejs2/node_modules/readable-stream/lib/_stream_writable.js:526:7)
    at Client.Writable.uncork (/Users/trentm/el/apm-agent-nodejs2/node_modules/readable-stream/lib/_stream_writable.js:321:94)
    at Client._fetchAndEncodeMetadata (/Users/trentm/el/apm-agent-nodejs2/node_modules/elastic-apm-http-client/index.js:107:10)
    at _conf.cloudMetadataFetcher.getCloudMetadata (/Users/trentm/el/apm-agent-nodejs2/node_modules/elastic-apm-http-client/index.js:584:7)
    at CallbackCoordination.<anonymous> (/Users/trentm/el/apm-agent-nodejs2/lib/cloud-metadata/index.js:123:7)
    at CallbackCoordination.emit (events.js:198:13)
    at CallbackCoordination.recordResult (/Users/trentm/el/apm-agent-nodejs2/lib/cloud-metadata/callback-coordination.js:125:14)
    at Timeout._onTimeout (/Users/trentm/el/apm-agent-nodejs2/lib/cloud-metadata/index.js:81:23)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```

E.g. with `./node_modules/.bin/tape test/central-config-enabled.js`:
https://gist.github.com/trentm/31a1b6c80d4eb85a0f368c91339bcb99


I added a test case in apm-nodejs-http-client that demonstrates this:

```
% ./node_modules/.bin/tape test/edge-cases.js
TAP version 13
# getCloudMetadata after client.destroy() should not result in error
# destroy client
ok 1 should emit close event
# calling back with cloud metadata
XXX uncork from metadata
not ok 2 should not get a client "error" event
  ---
    operator: error
    expected: |-
      undefined
    actual: |-
      [Error: Cannot call write after a stream was destroyed]
    at: Client.<anonymous> (/Users/trentm/el/apm-nodejs-http-client2/test/edge-cases.js:476:9)
    stack: |-
      Error: Cannot call write after a stream was destroyed
          at doWrite (/Users/trentm/el/apm-nodejs-http-client2/node_modules/readable-stream/lib/_stream_writable.js:409:38)
          at clearBuffer (/Users/trentm/el/apm-nodejs-http-client2/node_modules/readable-stream/lib/_stream_writable.js:526:7)
          at Client.Writable.uncork (/Users/trentm/el/apm-nodejs-http-client2/node_modules/readable-stream/lib/_stream_writable.js:321:94)
          at /Users/trentm/el/apm-nodejs-http-client2/index.js:109:10
          at /Users/trentm/el/apm-nodejs-http-client2/index.js:589:7
          at Timeout._onTimeout (/Users/trentm/el/apm-nodejs-http-client2/test/edge-cases.js:464:13)
          at listOnTimeout (internal/timers.js:554:17)
          at processTimers (internal/timers.js:497:7)
  ...

1..2
# tests 2
# pass  1
# fail  1
```

The "write after a stream was destroyed" can happen if **the http client is
`.destroy()`d before `cloudMetadataFetcher.getCloudMetadata()` returns**. This
obviously comes up in quick testing. In real usage I think it would be rare
(hence not a big issue) but *conceivable*, say, for a lambda cloud function
that starts and ends quickly.

The issue is that when `getCloudMetadata` returns it calls `this.uncork()`,
which unconditionally allows the client to start writing, using the now destroyed
stream.

## possible solution

Use `_maybeUncork`. It has an explicit guard on `this.destroyed`. Also FWIW,
it does a better job ensuring we don't double-uncork. (There is currently a
small race where we can call `this.uncork()` twice when corked: between
`_maybeUncork` and the `_fetchAndEncodeMetadata` callback. However, it
wouldn't have mattered because
[readable-stream's `uncork`](https://github.com/nodejs/readable-stream/blob/bcbe5e06b10a8915f622e6530f057f7a4ee1a09e/lib/_stream_writable.js#L319-L320)
ensures the `corked` count doesn't go negative.)

```diff
-    // this uncork reverse the .cork call in the constructor (above)
-    this.uncork()
+    // This reverses the cork() call in the constructor above. "Maybe" uncork,
+    // in case the client has been destroyed before this callback is called.
+    this._maybeUncork()
```

And that test case now:

```
% ./node_modules/.bin/tape test/edge-cases.js
TAP version 13
# client.destroy() before slow cloud metadata fetch should not error
# destroy client
ok 1 should emit close event
# calling back with cloud metadata

1..1
# tests 1
# pass  1

# ok
```


## a related test case

Making this change results in a test failure:

```
% ./node_modules/.bin/tape test/edge-cases.js
TAP version 13
# client.destroy() - should not allow more writes
ok 1 should emit error Cannot call write after a stream was destroyed
ok 2 should emit close
ok 3 should still call callback even though it's destroyed
ok 4 should still call callback even though it's destroyed
ok 5 should still call callback even though it's destroyed
ok 6 should still call callback even though it's destroyed
ok 7 should emit finish
ok 8 should still call callback even though it's destroyed
not ok 9 plan != count
  ---
    operator: fail
    expected: 11
    actual:   8
    at: Client.done (/Users/trentm/el/apm-nodejs-http-client2/test/edge-cases.js:408:28)
    stack: |-
      Error: plan != count
          at Test.assert [as _assert] (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:228:54)
          at Test.bound [as _assert] (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:80:32)
          at Test.fail (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:322:10)
          at Test.bound [as fail] (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:80:32)
          at Test._end (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:173:14)
          at Test.bound [as _end] (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:80:32)
          at Test.end (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:157:10)
          at Test.bound [as end] (/Users/trentm/el/apm-nodejs-http-client2/node_modules/tape/lib/test.js:80:32)
          at Client.done (/Users/trentm/el/apm-nodejs-http-client2/test/edge-cases.js:408:28)
          at Object.onceWrapper (events.js:421:28)
  ...

1..9
# tests 9
# pass  8
# fail  1
```

Here I'll argue we should just drop this test, because it isn't testing what it says it is.
Back on commit 03a5919d649b3c3cb9baf13879cc530e3dc45178 (PR #5) that test run looked like this:

```
% ./node_modules/.bin/tape test/test.js
TAP version 13
# client.destroy() - should not allow more writes
ok 1 should emit error write called on destroyed Elastic APM client
ok 2 should emit error write called on destroyed Elastic APM client
ok 3 should emit error write called on destroyed Elastic APM client
ok 4 should emit error flush called on destroyed Elastic APM client
ok 5 should emit close
ok 6 should still call callback even though it's destroyed
ok 7 should still call callback even though it's destroyed
ok 8 should still call callback even though it's destroyed
ok 9 should still call callback even though it's destroyed
ok 10 should emit error end called on destroyed Elastic APM client
ok 11 should emit finish
ok 12 should still call callback even though it's destroyed

1..12
# tests 12
# pass  12

# ok
```

Note the different "write called on destroyed Elastic APM client" error message.
That error message is from this code:

```js
Client.prototype._write = function (obj, enc, cb) {
  if (this._destroyed) {
    this.emit('error', new Error('write called on destroyed Elastic APM client'))
    cb()
  } else if (obj === flush) {
    if (this._active) {
      this._onflushed = cb
      this._chopper.chop()
    } else {
      this._chopper.chop(cb)
    }
  } else {
    this._stream.write(obj, cb)
  }
}
```

A subsequent commit dropped the "write called on destroyed ..." error event:

```diff
commit 5880b0c9a386e4ae96a1ad2b8dd9c5c98dc29e3d
Date:   2018-11-10T17:47:11+01:00 (2 years, 3 months ago)

    refactor: upgrade to readable-stream@3 (#29)
...
 Client.prototype._write = function (obj, enc, cb) {
-  if (this._destroyed) {
-    this.emit('error', new Error('write called on destroyed Elastic APM client'))
-    cb()
-  } else if (obj === flush) {
+  if (obj === flush) {
```

and the only update to the tests (because of a change in `client.end()`)

```diff
--- a/test/test.js
+++ b/test/test.js
@@ -1154,7 +1154,7 @@ test('client.destroy() - on fresh client', function (t) {
 })

 test('client.destroy() - should not allow more writes', function (t) {
-  t.plan(12)
+  t.plan(11)
   let count = 0
```

Subtly the error emitted is now "Cannot call write after a stream was destroyed", but
the test didn't check the error message.

```
% ./node_modules/.bin/tape test/edge-cases.js
TAP version 13
# client.destroy() - should not allow more writes
# calling back with cloud metadata
ok 1 should emit error Cannot call write after a stream was destroyed
ok 2 should emit error Cannot call write after a stream was destroyed
ok 3 should emit error Cannot call write after a stream was destroyed
ok 4 should emit error Cannot call write after a stream was destroyed
ok 5 should emit finish
ok 6 should emit close
ok 7 should still call callback even though it's destroyed
ok 8 should still call callback even though it's destroyed
ok 9 should still call callback even though it's destroyed
ok 10 should still call callback even though it's destroyed
ok 11 should still call callback even though it's destroyed

1..11
# tests 11
# pass  11

# ok
```

That error message is [`ERR_STREAM_DESTROYED` from node core](https://github.com/nodejs/node/blob/d345ac901caf374d0c5321dab5f72d4bfb3581b4/lib/internal/errors.js#L1396)

So while the test name is about "should not allow more writes [after client.destroy()]",
the current client is allowing exactly that.

I don't think there is any utility in this test case. The client used to emit
a custom error on attempts to write after `.destroy()`, now it emits a node
core error in the same case. Nothing to test here.
