### PR TITLE
fix: calling client.send*() after client.destroy() should not error

### DIFF
--- a/index.js
+++ b/index.js
@@ -390,21 +390,33 @@ Client.prototype._encode = function (obj, enc) {
 }
 
 Client.prototype.sendSpan = function (span, cb) {
+  if (this.destroyed) {
+    return
+  }
   this._maybeCork()
   return this.write({ span }, Client.encoding.SPAN, cb)
 }
 
 Client.prototype.sendTransaction = function (transaction, cb) {
+  if (this.destroyed) {
+    return
+  }
   this._maybeCork()
   return this.write({ transaction }, Client.encoding.TRANSACTION, cb)
 }
 
 Client.prototype.sendError = function (error, cb) {
+  if (this.destroyed) {
+    return
+  }
   this._maybeCork()
   return this.write({ error }, Client.encoding.ERROR, cb)
 }
 
 Client.prototype.sendMetricSet = function (metricset, cb) {
+  if (this.destroyed) {
+    return
+  }
   this._maybeCork()
   return this.write({ metricset }, Client.encoding.METRICSET, cb)
 }


### PR DESCRIPTION
Before this change calling client.sendTransaction() et al after
client.destroy() would stage the data to be written, then set the
_corkTimer timeout, after which it would uncork the stream and attempt
to write:
    Error: Cannot call write after a stream was destroyed