### PR TITLE
fix: crash on error polling config with node v12 and keep-alive agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 node_modules
 target
 coverage.lcov
+/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# elastic-apm-http-client changelog
+
+## Unreleased
+
+- Fix possible crash when polling apm-server for config. Specifically it
+  could happen with the Elastic Node.js APM agent when:
+
+  1. using node.js v12;
+  2. instrumenting one of hapi, restify, koa, express, or fastify; and
+  3. on a *second* request to APM server *that fails* (non-200 response).
+
+  https://github.com/elastic/apm-agent-nodejs/issues/1749
+
+## v9.5.0
+
+(This changelog was started after the 9.5.0 release.)

--- a/index.js
+++ b/index.js
@@ -836,7 +836,7 @@ function processConfigErrorResponse (res, buf, err) {
   if (!err) {
     err = new Error(errMsg)
   } else {
-    err.message = errMsg + ':' + err.message
+    err.message = errMsg + ': ' + err.message
   }
 
   err.code = res.statusCode


### PR DESCRIPTION
This will ultimately fix https://github.com/elastic/apm-agent-nodejs/issues/1749 when that repo is updated to use a new release of this package.

https://github.com/elastic/apm-agent-nodejs/issues/1749#issuecomment-782470960 best describes the issue.

The fix here is to not call `res.destroy(err)` on a res that we have already completed (even if it wasn't a 200 response, it was still a successfully completed response). To keep the fix targetted and small, this PR **does not** fix the issue with the keep-alive agent only being used after a second `client.config(...)` call. I'll open a separate PR for that work.