### PR TITLE
fix: ensure keep-alive HTTP(S) agent is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 # elastic-apm-http-client changelog
 
-## v9.5.1
+# unreleased
 
 - Fix config initialization such that the keep-alive agent is used all the
-  time as intended. Before this change the keep-alive HTTP(S) agent would
-  only be used if a second call to `client.config(...)` was made. For
-  the Elastic APM Agent's usage of this module, that was when any of the
-  express, fastify, restify, hapi, or koa modules was instrumented.
+  time, as intended. Before this change the keep-alive HTTP(S) agent would only
+  be used if a second call to `client.config(...)` was made. For the [Elastic
+  APM Agent](https://github.com/elastic/apm-agent-nodejs)'s usage of this
+  module, that was when any of the express, fastify, restify, hapi, or koa
+  modules was instrumented.
+
+  A compatibility note for direct users of this APM http-client:
+  Options passed to the
+  [`Writable`](https://nodejs.org/api/stream.html#stream_new_stream_writable_options)
+  and [`http[s].Agent`](https://nodejs.org/api/http.html#http_new_agent_options)
+  constructors no longer include the full options object passed to the
+  [Client constructor](https://github.com/elastic/apm-nodejs-http-client/blob/master/README.md#new-clientoptions).
+  Therefore usage of *undocumented* options can no longer be used.
+
+## v9.5.1
 
 - Fix possible crash when polling apm-server for config. Specifically it
   could happen with the Elastic Node.js APM agent when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v9.5.1
 
+- Fix config initialization such that the keep-alive agent is used all the
+  time as intended. Before this change the keep-alive HTTP(S) agent would
+  only be used if a second call to `client.config(...)` was made. For
+  the Elastic APM Agent's usage of this module, that was when any of the
+  express, fastify, restify, hapi, or koa modules was instrumented.
+
 - Fix possible crash when polling apm-server for config. Specifically it
   could happen with the Elastic Node.js APM agent when:
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ used to transmit it have ended.
 Update the configuration given to the `Client` constructor. All
 configuration options can be updated except:
 
-- The protocol part of the `serverUrl` (`http` vs `https`)
 - `size`
 - `time`
 - `keepAlive`

--- a/test/abort.js
+++ b/test/abort.js
@@ -48,6 +48,7 @@ test('abort request if server responds early', function (t) {
         res.end()
         clearTimeout(timer)
         server.close()
+        client.destroy() // Destroy keep-alive agent.
         t.end()
       })
     } else {

--- a/test/k8s.js
+++ b/test/k8s.js
@@ -20,7 +20,7 @@ test('no environment variables', function (t) {
     })
   }).client(function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -39,7 +39,7 @@ test('kubernetesNodeName only', function (t) {
     })
   }).client({ kubernetesNodeName: 'foo' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -58,7 +58,7 @@ test('kubernetesNamespace only', function (t) {
     })
   }).client({ kubernetesNamespace: 'foo' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -77,7 +77,7 @@ test('kubernetesPodName only', function (t) {
     })
   }).client({ kubernetesPodName: 'foo' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -96,7 +96,7 @@ test('kubernetesPodUID only', function (t) {
     })
   }).client({ kubernetesPodUID: 'foo' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -119,7 +119,7 @@ test('all', function (t) {
     })
   }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodName: 'baz', kubernetesPodUID: 'qux' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -141,7 +141,7 @@ test('all except kubernetesNodeName', function (t) {
     })
   }).client({ kubernetesNamespace: 'bar', kubernetesPodName: 'baz', kubernetesPodUID: 'qux' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -163,7 +163,7 @@ test('all except kubernetesNamespace', function (t) {
     })
   }).client({ kubernetesNodeName: 'foo', kubernetesPodName: 'baz', kubernetesPodUID: 'qux' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -186,7 +186,7 @@ test('all except kubernetesPodName', function (t) {
     })
   }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodUID: 'qux' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 
@@ -209,7 +209,7 @@ test('all except kubernetesPodUID', function (t) {
     })
   }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodName: 'baz' }, function (client) {
     client.sendError({})
-    client.flush()
+    client.flush(() => { client.destroy() })
   })
 })
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -111,7 +111,7 @@ function assertMetadata (t, obj) {
   t.ok(Array.isArray(_process.argv), 'process.title should be an array')
   t.ok(_process.argv.length >= 2, 'process.title should contain at least two elements')
   t.ok(/\/node$/.test(_process.argv[0]), `process.argv[0] should match /\\/node$/ (was: ${_process.argv[0]})`)
-  const regex = /(\/test\/(test|truncate|abort|edge-cases|lib\/unref-client)\.js|node_modules\/\.bin\/tape)$/
+  const regex = /(\/test\/.*\.js|node_modules\/\.bin\/tape)$/
   t.ok(regex.test(_process.argv[1]), `process.argv[1] should match ${regex} (was: ${_process.argv[1]})"`)
   const system = metadata.system
   t.ok(typeof system.hostname, 'string')

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -68,7 +68,9 @@ dataTypes.forEach(function (dataType) {
             }
           }
         })
-        client.flush()
+        client.flush(function () {
+          client.destroy() // Destroy keep-alive agent when done on client-side.
+        })
       })
     })
   })

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -105,7 +105,7 @@ options.forEach(function (opts) {
           }
         }
       })
-      client.flush()
+      client.flush(() => { client.destroy() })
     })
   })
 
@@ -180,7 +180,7 @@ options.forEach(function (opts) {
           }
         }
       })
-      client.flush()
+      client.flush(() => { client.destroy() })
     })
   })
 
@@ -231,7 +231,7 @@ options.forEach(function (opts) {
           }
         }
       })
-      client.flush()
+      client.flush(() => { client.destroy() })
     })
   })
 
@@ -352,7 +352,7 @@ options.forEach(function (opts) {
           }
         }
       })
-      client.flush()
+      client.flush(() => { client.destroy() })
     })
   })
 
@@ -397,7 +397,7 @@ options.forEach(function (opts) {
           }
         }
       })
-      client.flush()
+      client.flush(() => { client.destroy() })
     })
   })
 })


### PR DESCRIPTION
(This is a follow up on and depends on #138 going in first.)

Fix config initialization such that the keep-alive agent is used all the
time as intended. Before this change the keep-alive HTTP(S) agent would
only be used if a second call to `client.config(...)` was made. For
the Elastic APM Agent's usage of this module, that was when any of the
express, fastify, restify, hapi, or koa modules was instrumented.

## reviewer notes

- the creation of the HTTP(S) agent (this._agent) is moved into `Client.prototype.config` -- along with setting of `this._transport` for convenience.
    - As a minor side note the setting of _transport is taking the simplification from https://github.com/elastic/apm-nodejs-http-client/pull/125/files
- The calls to `Writable.call()` and `new _transport.Agent()` have been cleaned up to only pass in supported options rather than the whole `this._conf` object, to avoid possible surprise and noise (logging the Agent instance would dump the full `_conf`).
- The significant change for handling in the test suite was in "end of test" handling ensuring that the created client's keep-alive agent was destroyed. Otherwise the process would hang around until the default keep-alive socket timeout, which is 2 minutes. (Note: sometimes that "hang" would be much shorter -- on the order of a few seconds. I'm not sure what conditions led to a sometime shorter timeout on the agent closing idle sockets.)
- The client and the APM agent test suites pass with this change. (I haven't run the TAV tests.)