### PR TITLE
chore: disallow package-lock.json file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /package-lock.json
 /.nyc_output
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-package-lock.json
-.nyc_output
-node_modules
-target
-coverage.lcov
+/package-lock.json
+/.nyc_output
+/node_modules
+/coverage.lcov
 /tmp

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Also:
- anchors some .gitignore'd files to the root dir
- drops the "target" .gitignore because I don't know what that is meant to be from