### PR TITLE
9.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # elastic-apm-http-client changelog
 
-# unreleased
+# v9.6.0
 
 - Fix config initialization such that the keep-alive agent is used all the
   time, as intended. Before this change the keep-alive HTTP(S) agent would only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # elastic-apm-http-client changelog
 
-# v9.6.0
+## v9.6.0
 
 - Fix config initialization such that the keep-alive agent is used all the
   time, as intended. Before this change the keep-alive HTTP(S) agent would only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   be used if a second call to `client.config(...)` was made. For the [Elastic
   APM Agent](https://github.com/elastic/apm-agent-nodejs)'s usage of this
   module, that was when any of the express, fastify, restify, hapi, or koa
-  modules was instrumented.
+  modules was instrumented. ([#139](https://github.com/elastic/apm-nodejs-http-client/pull/139))
 
   A compatibility note for direct users of this APM http-client:
   Options passed to the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "9.5.1",
+  "version": "9.6.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Doing a release to get #139 out separate from a (hopefully) coming change for #136. I probably won't update apm-agent-nodejs' package.json until there is a release with #136.

I bumped the minor version because while the change was just a bug fix, I feel it is a potential significant enough change in behaviour. 