### PR TITLE
add optional pino logger and collection of internal stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Server.
 
 Arguments:
 
-- `options` - An object containing config options (see below)
+- `options` - An object containing config options (see below). All options
+  are optional, except those marked "(required)".
 
 Data sent to the APM Server as part of the metadata package:
 
@@ -151,9 +152,12 @@ Data sanitizing configuration:
 
 Debug options:
 
+- `logger` - A [pino](https://getpino.io) logger to use for trace and
+  debug-level logging.
 - `payloadLogFile` - Specify a file path to which a copy of all data
   sent to the APM Server should be written. The data will be in ndjson
-  format and will be uncompressed
+  format and will be uncompressed. Note that using this option can
+  impact performance.
 
 ### Event: `config`
 
@@ -218,9 +222,11 @@ The client is not closed when the `request-error` event is emitted.
 
 ### `client.sent`
 
-An integer indicating the number of events (spans, transactions, or errors)
-sent by the client. An event is considered sent when the HTTP request
-used to transmit it have ended.
+An integer indicating the number of events (spans, transactions, errors, or
+metricsets) sent by the client. An event is considered sent when the HTTP
+request used to transmit it has ended. Note that errors in requests to APM
+server may main this value is not the same as the number of events *accepted*
+by the APM server.
 
 ### `client.config(options)`
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The client is not closed when the `request-error` event is emitted.
 An integer indicating the number of events (spans, transactions, errors, or
 metricsets) sent by the client. An event is considered sent when the HTTP
 request used to transmit it has ended. Note that errors in requests to APM
-server may main this value is not the same as the number of events *accepted*
+server may mean this value is not the same as the number of events *accepted*
 by the APM server.
 
 ### `client.config(options)`

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,20 @@
+'use strict'
+
+// Logging utilities for the APM http client.
+
+// A logger that does nothing and supports enough of the pino API
+// (https://getpino.io/#/docs/api?id=logger) for use as a fallback in
+// this package.
+class NoopLogger {
+  trace () {}
+  debug () {}
+  info () {}
+  warn () {}
+  error () {}
+  fatal () {}
+  child () { return this }
+}
+
+module.exports = {
+  NoopLogger
+}


### PR DESCRIPTION
1. This adds a `logger` option to the client, which expects a pino logger. If not given, a "no-op" logger will be used to stay silent. This logger is documented to be for trace and debug-level logging only, i.e. nothing about logging for the user of this apmclient or the apm agent using this lib.
2. This collects some internal stats on elapsed times on the "_write*" functions where the sync delays are. Also a private `_getStats()` is added that can be used by dev/debugging scripts to dump info under load tests.

The matching APM agent PR is: https://github.com/elastic/apm-agent-nodejs/pull/2015

* * *

This is pre-support for a coming PR to fix https://github.com/elastic/apm-nodejs-http-client/issues/136
I'm trying to separate out some changes to make that change more focused.