### PR TITLE
fix: ignore codecov.io reporting failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "// scripts.test": "quoting arg to tape to avoid too long argv, let tape do globbing",
   "scripts": {
-    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && (codecov || echo 'warning: ignoring codecov failure')",
     "test": "standard && nyc tape \"test/*.js\""
   },
   "engines": {


### PR DESCRIPTION
Because of https://github.com/codecov/codecov-node/issues/284 codecov
reporting is sometimes failing. With the new default node v15 option
of '--unhandled-rejections=strict', this results in the occasional
non-zero exit status, which breaks our node v15 builds. This changes to
ignore that exit status.