### PR TITLE
fix: ensure client.flush(cb) callback is called when no active handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # elastic-apm-http-client changelog
 
+## Unreleased
+
+- Fix to ensure the `client.flush(cb)` callback is called in the (expected to
+  be rare) case where there are no active handles -- i.e., the process is
+  exiting.
+  ([#150](https://github.com/elastic/apm-nodejs-http-client/issues/150))
+
 ## v9.7.0
 
 - A number of changes were made to fix issues with the APM agent under heavy

--- a/index.js
+++ b/index.js
@@ -724,6 +724,7 @@ function getChoppedStreamHandler (client, onerror) {
           intakeResTimer = null
         }
       }
+      client._intakeRequestGracefulExitFn = null
 
       client.sent = client._numEventsEnqueued
       client._active = false

--- a/test/lib/call-me-back-maybe.js
+++ b/test/lib/call-me-back-maybe.js
@@ -1,0 +1,34 @@
+// A script, used by test/side-effects.js, to test that the client.flush
+// callback is called.
+//
+// We expect both `console.log`s to write their output.
+//
+// Two important things are required to reproduce the issue:
+// 1. There cannot be other activities going on that involve active libuv
+//    handles. For this Client that means:
+//    - ensure no `_pollConfig` requests via `centralConfig: false`
+//    - do not provide a `cloudMetadataFetcher`
+// 2. There must be a listening APM server to which to send data.
+
+const Client = require('../../') // elastic-apm-http-client
+
+const serverUrl = process.argv[2]
+
+const client = new Client({
+  // logger: require('pino')({ level: 'trace', ...require('@elastic/ecs-pino-format')() }, process.stderr), // uncomment for debugging
+  serverUrl: serverUrl,
+  serviceName: 'call-me-back-maybe',
+  agentName: 'my-nodejs-agent',
+  agentVersion: '1.2.3',
+  userAgent: 'my-nodejs-agent/1.2.3',
+  centralConfig: false // important for repro, see above
+})
+
+const e = { exception: { message: 'boom', type: 'Error' } }
+
+client.sendError(e, function sendCb () {
+  console.log('sendCb called')
+  client.flush(function flushCb () {
+    console.log('flushCb called')
+  })
+})


### PR DESCRIPTION
Fixes: #150

Explanation of the issue and fix is on #150.