### PR TITLE
9.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # elastic-apm-http-client changelog
 
-## Unreleased
+## v9.7.1
 
 - Fix to ensure the `client.flush(cb)` callback is called in the (expected to
   be rare) case where there are no active handles -- i.e., the process is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "9.7.0",
+  "version": "9.7.1",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
To get a fix out for the (rare) behaviour change in 9.7.0.

Eventually (once https://github.com/elastic/apm-agent-nodejs/pull/2024 is ready), the apm-agent-nodejs will move back to using `"elastic-apm-http-client": "^9.7.1"`.