### PR TITLE
feat: client.addMetadataFilter(fn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # elastic-apm-http-client changelog
 
+## Unreleased
+
+- Add `client.addMetadataFilter(fn)`. See the
+  [APM agent issue](https://github.com/elastic/apm-agent-nodejs/issues/1916).
+
 ## v9.7.1
 
 - Fix to ensure the `client.flush(cb)` callback is called in the (expected to

--- a/README.md
+++ b/README.md
@@ -263,8 +263,11 @@ configuration options can be updated except:
 ### `client.addMetadataFilter(fn)`
 
 Add a filter function for the ["metadata" object](https://www.elastic.co/guide/en/apm/server/current/metadata-api.html)
-sent to APM server. Here is an example of a filter that removes the
-`metadata.process.argv` field:
+sent to APM server. This will be called once at client creation, and possibly
+again later if `client.config()` is called to reconfigure the client or
+`client.addMetadataFilter(fn)` is called to add additional filters.
+
+Here is an example of a filter that removes the `metadata.process.argv` field:
 
 ```js
 apm.addMetadataFilter(function dropArgv(md) {

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Arguments:
 - `options` - An object containing config options (see below). All options
   are optional, except those marked "(required)".
 
-Data sent to the APM Server as part of the metadata package:
+Data sent to the APM Server as part of the [metadata object](https://www.elastic.co/guide/en/apm/server/current/metadata-api.html):
 
 - `agentName` - (required) The APM agent name
 - `agentVersion` - (required) The APM agent version
@@ -259,6 +259,37 @@ configuration options can be updated except:
 - `maxSockets`
 - `maxFreeSockets`
 - `centralConfig`
+
+### `client.addMetadataFilter(fn)`
+
+Add a filter function for the ["metadata" object](https://www.elastic.co/guide/en/apm/server/current/metadata-api.html)
+sent to APM server. Here is an example of a filter that removes the
+`metadata.process.argv` field:
+
+```js
+apm.addMetadataFilter(function dropArgv(md) {
+  if (md.process && md.process.argv) {
+    delete md.process.argv
+  }
+  return md
+})
+```
+
+It is up to the user to ensure the returned object conforms to the
+[metadata schema](https://www.elastic.co/guide/en/apm/server/current/metadata-api.html),
+otherwise APM data injest will be broken. An example of that (when used with
+the Node.js APM agent) is this in the application's log:
+
+```
+[2021-04-14T22:28:35.419Z] ERROR (elastic-apm-node): APM Server transport error (400): Unexpected APM Server response
+APM Server accepted 0 events in the last request
+Error: validation error: 'metadata' required
+  Document: {"metadata":null}
+```
+
+See the [APM Agent `addMetadataFilter` documentation](https://www.elastic.co/guide/en/apm/agent/nodejs/current/agent-api.html#apm-add-metadata-filter)
+for further details.
+
 
 ### `client.sendSpan(span[, callback])`
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "end-of-stream": "^1.4.4",
     "fast-safe-stringify": "^2.0.7",
     "fast-stream-to-buffer": "^1.0.0",
+    "object-filter-sequence": "^1.0.0",
     "readable-stream": "^3.4.0",
     "stream-chopper": "^3.0.1",
     "unicode-byte-truncate": "^1.0.0"

--- a/test/metadata-filter.js
+++ b/test/metadata-filter.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const test = require('tape')
+const utils = require('./lib/utils')
+
+const APMServer = utils.APMServer
+const processIntakeReq = utils.processIntakeReq
+
+test('addMetadataFilter', function (t) {
+  let theMetadata
+
+  const server = APMServer(function (req, res) {
+    const objStream = processIntakeReq(req)
+    let n = 0
+    objStream.on('data', function (obj) {
+      if (++n === 1) {
+        theMetadata = obj.metadata
+      }
+    })
+    objStream.on('end', function () {
+      res.statusCode = 202
+      res.end()
+    })
+  })
+
+  server.client(function (client) {
+    client.addMetadataFilter(function (md) {
+      delete md.process.argv
+      md.labels = { foo: 'bar' }
+      return md
+    })
+
+    client.sendSpan({ foo: 42 })
+    client.flush(function () {
+      t.ok(theMetadata, 'APM server got metadata')
+      t.equal(theMetadata.process.argv, undefined, 'metadata.process.argv was removed')
+      t.equal(theMetadata.labels.foo, 'bar', 'metadata.labels.foo was added')
+      client.end()
+      server.close()
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
A facility to custom filter the "metadata" object sent to APM server at
the start of every intake request.

This refactors setting of `_encodedMetadata` to happen in only one
place (`_resetEncodedMetadata`), so that it can apply the metadata
filters in only on place.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/1916