### PR TITLE
chore: drop codecov.io usage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
     PIPELINE_LOG_LEVEL='INFO'
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    CODECOV_SECRET = "secret/apm-team/ci/${env.REPO}-codecov"
   }
   options {
     timeout(time: 30, unit: 'MINUTES')
@@ -85,7 +84,6 @@ def generateStep(version){
           dir('target'){
             tap2Junit(pattern: '*-output.tap', suffix: 'junit.xml', package: 'APM http client')
           }
-          codecov(repo: env.REPO, basedir: ".", secret: "${CODECOV_SECRET}")
         }
       }
     }

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -21,4 +21,3 @@ npm --version
 nvm --version
 npm install
 npm test | tee ${TARGET_FOLDER}/test-suite-output.tap
-npm run coverage

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,0 @@
-# Disable comments on Pull Requests
-comment: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,3 @@ jobs:
         node-version: ${{ matrix.node }}
     - run: npm install
     - run: npm test
-    - run: npm run coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 /package-lock.json
 /.nyc_output
 /node_modules
-/coverage.lcov
 /target
 /tmp

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![npm](https://img.shields.io/npm/v/elastic-apm-http-client.svg)](https://www.npmjs.com/package/elastic-apm-http-client)
 [![Test status in GitHub Actions](https://github.com/elastic/apm-nodejs-http-client/workflows/Test/badge.svg)](https://github.com/elastic/apm-nodejs-http-client/actions)
 [![Build Status in Jenkins](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-nodejs%2Fapm-nodejs-http-client-mbp%2Fmaster)](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-nodejs-http-client-mbp/job/master/)
-[![codecov](https://img.shields.io/codecov/c/github/elastic/apm-nodejs-http-client.svg)](https://codecov.io/gh/elastic/apm-nodejs-http-client)
 
 A low-level HTTP client for communicating with the Elastic APM intake
 API version 2. For support for version 1, use version 5.x of this

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   ],
   "// scripts.test": "quoting arg to tape to avoid too long argv, let tape do globbing",
   "scripts": {
-    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && (codecov || echo 'warning: ignoring codecov failure')",
     "test": "standard && nyc tape \"test/*.js\""
   },
   "engines": {
@@ -31,7 +30,6 @@
     "unicode-byte-truncate": "^1.0.0"
   },
   "devDependencies": {
-    "codecov": "^3.6.1",
     "ndjson": "^1.5.0",
     "nyc": "^14.1.1",
     "semver": "^6.3.0",


### PR DESCRIPTION
After some discussion, it was agreed we aren't getting utility out of
uploading coverage info to codecov.io. We still have a coverage report
from 'npm test'.