### PR TITLE
fix: do not trace APM server client requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # elastic-apm-http-client changelog
 
+## v9.9.0
+
+- feat: Use uninstrumented HTTP(S) client request functions to avoid tracing
+  requests made by the APM agent itself.
+  ([#161](https://github.com/elastic/apm-nodejs-http-client/pull/161))
+
 ## v9.8.1
 
 - perf: eliminate encodeObject stack and faster loop in `_writeBatch`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "9.8.1",
+  "version": "9.9.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Use uninstrumented https.request() et al (grabbing references before the
agent does shimming) for requests to APM server. This avoids them
interfering in tracing (adding trace-context headers to APM server
requests, emitting debug logs about spans). This will fix
https://github.com/elastic/apm-agent-nodejs/issues/1995