### PR TITLE
feat: truncation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # elastic-apm-http-client changelog
 
+## v10.0.0
+
+- All truncation of string fields (per `truncate*At` config options) have
+  changed from truncating at a number of unicode chars, rather than a number
+  of bytes. This is both faster and matches [the json-schema spec](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.3.1)
+  for [apm-server intake fields](https://www.elastic.co/guide/en/apm/server/current/events-api.html#events-api-schema-definition)
+  that specify `maxLength`.
+- BREAKING CHANGE: The `truncateQueriesAt` config option has been removed.
+- In its place the `truncateLongFieldsAt` config option has been added to cover
+  `span.context.db.statement` and a number of other possibly-long fields (per
+  [spec](https://github.com/elastic/apm/blob/master/specs/agents/field-limits.md#long_field_max_length-configuration)).
+  This *does* mean that in rare cases of long field values longer than the
+  default 10000 chars, this change will result in those values being truncated.
+- The `truncateErrorMessagesAt` config option has been deprecated, in favor
+  of `truncateLongFieldsAt`. Note, however, that `truncateLongFieldsAt` does
+  *not* support the special case `-1` value to disable truncation. If
+  `truncateErrorMessagesAt` is not specified, the value for
+  `truncateLongFieldsAt` is used. This means the effective default is now 10000,
+  no longer 2048.
+
 ## v9.9.0
 
 - feat: Use uninstrumented HTTP(S) client request functions to avoid tracing

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Streaming configuration:
 - `size` - The maxiumum compressed body size (in bytes) of each HTTP
   request to the APM Server. An overshoot of up to the size of the
   internal zlib buffer should be expected as the buffer is flushed after
-  this limit is reached. The default zlib buffer size is 16 kb (default:
+  this limit is reached. The default zlib buffer size is 16kB. (default:
   `768000` bytes)
 - `time` - The maxiumum number of milliseconds a streaming HTTP request
   to the APM Server can be ongoing before it's ended. Set to `-1` to
@@ -155,18 +155,24 @@ Streaming configuration:
 
 Data sanitizing configuration:
 
-- `truncateKeywordsAt` - Maximum size in bytes for strings stored as
-  Elasticsearch keywords. Strings larger than this will be trucated
-  (default: `1024` bytes)
-- `truncateErrorMessagesAt` - The maximum size in bytes for error
-  messages. Messages above this length will be truncated. Set to `-1` to
-  disable truncation. This applies to the following properties:
-  `error.exception.message` and `error.log.message` (default: `2048`
-  bytes)
-- `truncateStringsAt` - The maximum size in bytes for strings.
-  String values above this length will be truncated (default: `1024` bytes)
-- `truncateQueriesAt` - The maximum size in bytes for database queries.
-  Queries above this length will be truncated (default: `10000` bytes)
+- `truncateKeywordsAt` - Maximum size in unicode characters for strings stored
+  as Elasticsearch keywords. Strings larger than this will be trucated
+  (default: `1024`)
+- `truncateLongFieldsAt` - The maximum size in unicode characters for a
+  specific set of long string fields. String values above this length will be
+  truncated. Default: `10000`. This applies to the following fields:
+    - `transaction.context.request.body`, `error.context.request.body`
+    - `transaction.context.message.body`, `span.context.message.body`, `error.context.message.body`
+    - `span.context.db.statement`
+    - `error.exception.message` (unless `truncateErrorMessagesAt` is specified)
+    - `error.log.message` (unless `truncateErrorMessagesAt` is specified)
+- `truncateStringsAt` - The maximum size in unicode characters for strings.
+  String values above this length will be truncated (default: `1024`)
+- `truncateErrorMessagesAt` - **DEPRECATED:** prefer `truncateLongFieldsAt`.
+  The maximum size in unicode characters for error messages. Messages above this
+  length will be truncated. Set to `-1` to disable truncation. This applies to
+  the following properties: `error.exception.message` and `error.log.message`.
+  (default: `2048`)
 
 Debug options:
 

--- a/index.js
+++ b/index.js
@@ -184,10 +184,10 @@ Client.prototype.config = function (opts) {
   if (!this._conf.hostname) this._conf.hostname = hostname
   if (!this._conf.environment) this._conf.environment = process.env.NODE_ENV || 'development'
   if (!this._conf.truncateKeywordsAt) this._conf.truncateKeywordsAt = 1024
-  if (!this._conf.truncateErrorMessagesAt) this._conf.truncateErrorMessagesAt = 2048
   if (!this._conf.truncateStringsAt) this._conf.truncateStringsAt = 1024
   if (!this._conf.truncateCustomKeysAt) this._conf.truncateCustomKeysAt = 1024
-  if (!this._conf.truncateQueriesAt) this._conf.truncateQueriesAt = 10000
+  if (!this._conf.truncateLongFieldsAt) this._conf.truncateLongFieldsAt = 10000
+  // The deprecated `truncateErrorMessagesAt` will be honored if specified.
   if (!this._conf.bufferWindowTime) this._conf.bufferWindowTime = 20
   if (!this._conf.bufferWindowSize) this._conf.bufferWindowSize = 50
   if (!this._conf.maxQueueSize) this._conf.maxQueueSize = 1024

--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -8,6 +8,37 @@ exports.span = truncSpan
 exports.error = truncError
 exports.metricset = truncMetricSet
 
+// Truncate the string `s` to a `max` maximum number of JavaScript characters.
+//
+// Note that JavaScript uses UCS-2 internally, so characters outside of the
+// BMP are represented as surrogate pairs. These count as *two* characters.
+// The result is that a string with surrogate pairs will appear to be truncated
+// shorter than expected:
+//    unitrunc('aaaa', 4) // => 'aaaa'
+//    unitrunc('😂😂😂😂', 4) // => '😂😂'
+//
+// This will avoid truncating in the middle of a surrogate pair by truncating
+// one character earlier. For example:
+//    unitrunc('foo😂bar', 4) // => 'foo'
+function unitrunc (s, max) {
+  if (s.length > max) {
+    if (max <= 0) {
+      return ''
+    }
+    // If the last character is a "high" surrogate (D800–DBFF) per
+    // https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Surrogates
+    // then we would truncate in the middle of a surrogate pair. Move back one
+    // char to have a clean(er) truncation.
+    const endChar = s.charCodeAt(max - 1)
+    if (endChar >= 0xd800 && endChar <= 0xdbff) {
+      return s.slice(0, max - 1)
+    } else {
+      return s.slice(0, max)
+    }
+  }
+  return s
+}
+
 function truncMetadata (metadata, opts) {
   return breadthFilter(metadata, {
     onArray,
@@ -97,10 +128,7 @@ function truncMetadata (metadata, opts) {
           break
       }
 
-      if (value.length > max) {
-        return value.slice(0, max)
-      }
-      return value
+      return unitrunc(value, max)
     }
   })
 }
@@ -132,10 +160,7 @@ function truncTransaction (trans, opts) {
           break
       }
 
-      if (value.length > max) {
-        return value.slice(0, max)
-      }
-      return value
+      return unitrunc(value, max)
     }
   })
 
@@ -173,10 +198,7 @@ function truncSpan (span, opts) {
           break
       }
 
-      if (value.length > max) {
-        return value.slice(0, max)
-      }
-      return value
+      return unitrunc(value, max)
     }
   })
 
@@ -266,10 +288,7 @@ function truncError (error, opts) {
           break
       }
 
-      if (value.length > max) {
-        return value.slice(0, max)
-      }
-      return value
+      return unitrunc(value, max)
     }
   })
 }
@@ -287,10 +306,7 @@ function truncMetricSet (metricset, opts) {
         ? opts.truncateKeywordsAt
         : opts.truncateStringsAt
 
-      if (value.length > max) {
-        return value.slice(0, max)
-      }
-      return value
+      return unitrunc(value, max)
     }
   })
 }
@@ -393,10 +409,7 @@ function truncateCustomKeys (value, max, keywords) {
     if (keywords.includes(k)) {
       return k
     }
-    if (k.length > max) {
-      return k.slice(0, max)
-    }
-    return k
+    return unitrunc(k, max)
   })
 
   for (const [index, k] of keys.entries()) {

--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var breadthFilter = require('breadth-filter')
-var truncate = require('unicode-byte-truncate')
 
 exports.metadata = truncMetadata
 exports.transaction = truncTransaction
@@ -98,7 +97,10 @@ function truncMetadata (metadata, opts) {
           break
       }
 
-      return truncate(value, max)
+      if (value.length > max) {
+        return value.slice(0, max)
+      }
+      return value
     }
   })
 }
@@ -130,7 +132,10 @@ function truncTransaction (trans, opts) {
           break
       }
 
-      return truncate(value, max)
+      if (value.length > max) {
+        return value.slice(0, max)
+      }
+      return value
     }
   })
 
@@ -168,7 +173,10 @@ function truncSpan (span, opts) {
           break
       }
 
-      return truncate(value, max)
+      if (value.length > max) {
+        return value.slice(0, max)
+      }
+      return value
     }
   })
 
@@ -227,10 +235,12 @@ function truncError (error, opts) {
               break
 
             case 'message':
-              if (opts.truncateErrorMessagesAt >= 0) {
-                max = opts.truncateErrorMessagesAt
+              if (opts.truncateErrorMessagesAt === undefined) {
+                max = opts.truncateLongFieldsAt
+              } else if (opts.truncateErrorMessagesAt < 0) {
+                return value // skip truncation
               } else {
-                return value
+                max = opts.truncateErrorMessagesAt
               }
               break
           }
@@ -244,17 +254,22 @@ function truncError (error, opts) {
               max = opts.truncateKeywordsAt
               break
             case 'message':
-              if (opts.truncateErrorMessagesAt >= 0) {
-                max = opts.truncateErrorMessagesAt
+              if (opts.truncateErrorMessagesAt === undefined) {
+                max = opts.truncateLongFieldsAt
+              } else if (opts.truncateErrorMessagesAt < 0) {
+                return value // skip truncation
               } else {
-                return value
+                max = opts.truncateErrorMessagesAt
               }
               break
           }
           break
       }
 
-      return truncate(value, max)
+      if (value.length > max) {
+        return value.slice(0, max)
+      }
+      return value
     }
   })
 }
@@ -272,7 +287,10 @@ function truncMetricSet (metricset, opts) {
         ? opts.truncateKeywordsAt
         : opts.truncateStringsAt
 
-      return truncate(value, max)
+      if (value.length > max) {
+        return value.slice(0, max)
+      }
+      return value
     }
   })
 }
@@ -281,7 +299,13 @@ function contextLength (path, opts) {
   switch (path[1]) {
     case 'db':
       if (path[2] === 'statement') {
-        return opts.truncateQueriesAt
+        return opts.truncateLongFieldsAt
+      }
+      break
+
+    case 'message':
+      if (path[2] === 'body') {
+        return opts.truncateLongFieldsAt
       }
       break
 
@@ -290,6 +314,9 @@ function contextLength (path, opts) {
         case 'method':
         case 'http_version':
           return opts.truncateKeywordsAt
+
+        case 'body':
+          return opts.truncateLongFieldsAt
 
         case 'url':
           switch (path[3]) {
@@ -362,7 +389,15 @@ function truncateCustomKeys (value, max, keywords) {
   }
   const result = value
   const keys = Object.keys(result)
-  const truncatedKeys = keys.map(k => keywords.includes(k) ? k : truncate(k, max))
+  const truncatedKeys = keys.map(k => {
+    if (keywords.includes(k)) {
+      return k
+    }
+    if (k.length > max) {
+      return k.slice(0, max)
+    }
+    return k
+  })
 
   for (const [index, k] of keys.entries()) {
     const value = result[k]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "9.9.0",
+  "version": "10.0.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {
@@ -26,8 +26,7 @@
     "fast-stream-to-buffer": "^1.0.0",
     "object-filter-sequence": "^1.0.0",
     "readable-stream": "^3.4.0",
-    "stream-chopper": "^3.0.1",
-    "unicode-byte-truncate": "^1.0.0"
+    "stream-chopper": "^3.0.1"
   },
   "devDependencies": {
     "ndjson": "^1.5.0",

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -452,3 +452,22 @@ test('truncate cloud metadata', function (t) {
 
   t.end()
 })
+
+test('do not break surrogate pairs in truncation', function (t) {
+  const span = {
+    name: 'theSpan',
+    type: 'theType',
+    context: {
+      db: {
+        statement: 'foo🎉bar'
+      }
+    }
+  }
+  const truncateLongFieldsAt = 4
+  const truncatedSpan = truncate.span(span, { truncateLongFieldsAt })
+  t.ok(truncatedSpan.context.db.statement.length <= truncateLongFieldsAt,
+    'context.db.statement was truncated')
+  t.equal(truncatedSpan.context.db.statement, 'foo',
+    'context.db.statement was truncated without breaking a surrogate pair')
+  t.end()
+})

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -12,19 +12,19 @@ const truncate = require('../lib/truncate')
 
 const options = [
   {}, // default options
-  { truncateKeywordsAt: 100, truncateErrorMessagesAt: 200, truncateStringsAt: 300, truncateQueriesAt: 400 },
+  { truncateKeywordsAt: 100, truncateErrorMessagesAt: 200, truncateStringsAt: 300, truncateLongFieldsAt: 400 },
   { truncateErrorMessagesAt: -1 }
 ]
 
 options.forEach(function (opts) {
   const veryLong = 12000
   const lineLen = opts.truncateStringsAt || 1024
-  const queryLen = opts.truncateQueriesAt || 10000
+  const longFieldLen = opts.truncateLongFieldsAt || 10000
   const keywordLen = opts.truncateKeywordsAt || 1024
   const customKeyLen = opts.truncateCustomKeysAt || 1024
   const errMsgLen = opts.truncateErrorMessagesAt === -1
     ? veryLong
-    : (opts.truncateErrorMessagesAt || 2048)
+    : (opts.truncateErrorMessagesAt || longFieldLen)
 
   test('truncate transaction', function (t) {
     t.plan(assertIntakeReq.asserts + assertMetadata.asserts + assertEvent.asserts)
@@ -127,7 +127,7 @@ options.forEach(function (opts) {
               foo: genStr('m', lineLen)
             },
             db: {
-              statement: genStr('n', queryLen)
+              statement: genStr('n', longFieldLen)
             },
             destination: {
               address: genStr('o', keywordLen),


### PR DESCRIPTION
- Truncate on number of chars, not bytes. The "maxLength" values in json schema (for the intake API) are [intended to be in JSON characters](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.3.1), i.e. unicode chars -- so this is a valid change. Truncating on chars (`str.length` check) is also *much* faster than the `unicode-byte-truncate` algorithm was.
- Remove truncateQueriesAt, add truncateLongFieldsAt which covers that
  and the other fields specified for [`long_field_max_length`](https://github.com/elastic/apm/blob/master/specs/agents/field-limits.md#long_field_max_length-configuration).
- Deprecate truncateErrorMessagesAt. If unspecified, the
  truncateLongFieldsAt value will be used.

BREAKING CHANGE. This "breaking" is for the http-client's API because `truncateQueriesAt` is being dropped, hence the bump to v10. However, it isn't a breaking change for the agent (at least not this part of it).

Refs: https://github.com/elastic/apm-agent-nodejs/pull/2193