### PR TITLE
feat: ensure refed socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # elastic-apm-http-client changelog
 
+## unreleased
+
+- feat: Added code to `ref` the intake request socket during a graceful exit in order to   
+  ensure the client completes sending data in an AWS Lambda environment.  
+
 ## v10.0.0
 
 - All truncation of string fields (per `truncate*At` config options) have

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## unreleased
 
-- feat: Added code to `ref` the intake request socket during a graceful exit in order to   
-  ensure the client completes sending data in an AWS Lambda environment.  
+- feat: Added code to `ref` the intake request socket during a graceful exit in
+  order to  ensure the client completes sending data after a flush in an AWS Lambda
+  environment.
 
 ## v10.0.0
 

--- a/index.js
+++ b/index.js
@@ -800,7 +800,7 @@ function getChoppedStreamHandler (client, onerror) {
     // to gracefully shutdown, i.e. finish up quickly.
     let intakeReqSocket = null
     client._intakeRequestGracefulExitFn = () => {
-      // ensure intake request socket is reffed -- otherwise lambda
+      // Ensure intake request socket is reffed -- otherwise lambda
       // functions will freeze prior to data being sent.
       if (intakeReqSocket) {
         intakeReqSocket.ref()


### PR DESCRIPTION
Addresses https://github.com/elastic/apm-nodejs-http-client/issues/165

This PR addresses the following

> The use of an unrefed socket/connection can lead to a lambda function freezing before all data has been sent. This, in turn, can lead to the data being lost when the lambda unfreezes due to a closed connection

by ensuring the socket is `ref`ed, which will prevent the Lambda function from exiting early.  

Additionally, with this fix in place _and_ with the agent communicating with the lambda extension prototype (vs. communicating directly with a remote APM server), the following problem

> We've observed when using the lambda callback based API (vs. using an async function or a returned promise) that the client's stream can be rendered un-writable.

was not present. 