### PR TITLE
10.3.0; expectExtraMetadata config & Client#setExtraMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # elastic-apm-http-client changelog
 
+## v10.3.0
+
+- Add the `expectExtraMetadata: true` configuration option and
+  `Client#setExtraMetadata(metadata)` method to provide a mechanism for the
+  Node.js APM Agent to pass in metadata asynchronously and be sure that the
+  client will not begin an intake request until that metadata is provided.
+  This is to support passing in [AWS Lambda metadata that cannot be gathered
+  until the first Lambda function
+  invocation](https://github.com/elastic/apm-agent-nodejs/issues/2404).
+  (Note: The `expectExtraMetadata` option cannot be used in combination with
+  `cloudMetadataFetcher`.)
+
 ## v10.2.0
 
 - The client will no longer append data to the configured `userAgent` string.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ HTTP client configuration:
 - `maxFreeSockets` - Maximum number of sockets to leave open in a free
   state. Only relevant if `keepAlive` is set to `true` (default: `256`)
 
+Cloud & Extra Metadata Configuration:
+
+- `cloudMetadataFetcher` - An object with a `getCloudMetadata(cb)` method
+  for fetching metadata related to the current cloud environment. The callback
+  is of the form `function (err, cloudMetadata)` and the returned `cloudMetadata`
+  will be set on `metadata.cloud` for intake requests to APM Server. If
+  provided, this client will not begin any intake requests until the callback
+  is called. The `cloudMetadataFetcher` option must not be used with the
+  `expectExtraMetadata` option.
+- `expectExtraMetadata` - A boolean option to indicate that the client should
+  not allow any intake requests to begin until `cloud.setExtraMetadata(...)`
+  has been called. It is the responsibility of the caller to call
+  `cloud.setExtraMetadata()`. If not, then the Client will never perform an
+  intake request. The `expectExtraMetadata` option must not be used with the
+  `cloudMetadataFetcher` option.
+
 APM Agent Configuration via Kibana:
 
 - `centralConfig` - Whether or not the client should poll the APM
@@ -298,6 +314,18 @@ Error: validation error: 'metadata' required
 See the [APM Agent `addMetadataFilter` documentation](https://www.elastic.co/guide/en/apm/agent/nodejs/current/agent-api.html#apm-add-metadata-filter)
 for further details.
 
+### `client.setExtraMetadata([metadata])`
+
+Add extra metadata to be included in the "metadata" object sent to APM Server in
+intake requests. The given `metadata` object is merged into the metadata
+determined from the client configuration.
+
+The reason this exists is to allow some metadata to be provided asynchronously,
+especially in combination with the `expectExtraMetadata` configuration option
+to ensure that event data is not sent to APM Server until this extra metadata
+is provided. For example, in an AWS Lambda function some metadata is not
+available until the first function invocation -- which is some async time after
+Client creation.
 
 ### `client.sendSpan(span[, callback])`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/test/expectExtraMetadata.test.js
+++ b/test/expectExtraMetadata.test.js
@@ -1,0 +1,94 @@
+'use strict'
+
+// Test usage of `expectExtraMetadata: true` and `setExtraMetadata()`.
+
+const test = require('tape')
+const utils = require('./lib/utils')
+
+const APMServer = utils.APMServer
+const processIntakeReq = utils.processIntakeReq
+
+test('expectExtraMetadata and setExtraMetadata used properly', function (t) {
+  const apmEvents = []
+
+  const server = APMServer(function (req, res) {
+    const objStream = processIntakeReq(req)
+    objStream.on('data', function (obj) {
+      apmEvents.push(obj)
+    })
+    objStream.on('end', function () {
+      res.statusCode = 202
+      res.end()
+    })
+  }).client({ expectExtraMetadata: true }, function (client) {
+    client.setExtraMetadata({
+      foo: 'bar',
+      service: {
+        runtime: {
+          name: 'MyLambda'
+        }
+      }
+    })
+    client.sendTransaction({ req: 1 })
+
+    client.flush(() => {
+      t.equal(apmEvents.length, 2, 'APM Server got 2 events')
+      t.ok(apmEvents[0].metadata, 'event 0 is metadata')
+      t.equal(apmEvents[0].metadata.foo, 'bar', 'setExtraMetadata added "foo" field')
+      t.equal(apmEvents[0].metadata.service.runtime.name, 'MyLambda',
+        'setExtraMetadata set nested service.runtime.name field properly')
+      t.ok(apmEvents[1].transaction, 'event 1 is a transaction')
+
+      client.end()
+      server.close()
+      t.end()
+    })
+  })
+})
+
+test('empty setExtraMetadata is fine, and calling after send* is fine', function (t) {
+  const apmEvents = []
+
+  const server = APMServer(function (req, res) {
+    const objStream = processIntakeReq(req)
+    objStream.on('data', function (obj) {
+      apmEvents.push(obj)
+    })
+    objStream.on('end', function () {
+      res.statusCode = 202
+      res.end()
+    })
+  }).client({ expectExtraMetadata: true }, function (client) {
+    client.sendTransaction({ req: 1 })
+    client.setExtraMetadata()
+
+    client.flush(() => {
+      t.equal(apmEvents.length, 2, 'APM Server got 2 events')
+      t.ok(apmEvents[0].metadata, 'event 0 is metadata')
+      t.ok(apmEvents[1].transaction, 'event 1 is a transaction')
+
+      client.end()
+      server.close()
+      t.end()
+    })
+  })
+})
+
+test.only('no setExtraMetadata call results in a corked client', function (t) {
+  const server = APMServer(function (req, res) {
+    t.fail('do NOT expect to get intake request to APM server')
+  }).client({ expectExtraMetadata: true }, function (client) {
+    // Explicitly *not* calling setExtraMetadata().
+    client.sendTransaction({ req: 1 })
+
+    client.flush(() => {
+      t.fail('should *not* callback from flush')
+    })
+    setTimeout(() => {
+      t.pass('hit timeout without an intake request to APM server')
+      client.destroy()
+      server.close()
+      t.end()
+    }, 1000)
+  })
+})

--- a/test/expectExtraMetadata.test.js
+++ b/test/expectExtraMetadata.test.js
@@ -74,7 +74,7 @@ test('empty setExtraMetadata is fine, and calling after send* is fine', function
   })
 })
 
-test.only('no setExtraMetadata call results in a corked client', function (t) {
+test('expectExtraMetadata:true with *no* setExtraMetadata call results in a corked client', function (t) {
   const server = APMServer(function (req, res) {
     t.fail('do NOT expect to get intake request to APM server')
   }).client({ expectExtraMetadata: true }, function (client) {

--- a/test/writev.test.js
+++ b/test/writev.test.js
@@ -71,30 +71,21 @@ dataTypes.forEach(function (dataType) {
 
   test(`bufferWindowTime - custom value (${dataType})`, function (t) {
     const server = APMServer().client({ bufferWindowTime: 150 }, function (client) {
-      // Cloud metadata fetching means that a write (via `client.sendSpan()` or
-      // similar) does *not* mean an immediately active outgoing request until
-      // *some time after* cloud metadata is fetched. That "some time after" is
-      // after (a) the "cloud-metadata" event, plus (b) the `nextTick()` in
-      // `_maybeUncork()` before calling `uncork()`.
-      client.on('cloud-metadata', function () {
-        process.nextTick(function () {
-          client[sendFn]({ req: 1 })
-          t.ok(client._writableState.corked, 'should be corked')
+      client[sendFn]({ req: 1 })
+      t.ok(client._writableState.corked, 'should be corked')
 
-          // Wait twice as long as the default bufferWindowTime
-          setTimeout(function () {
-            t.ok(client._writableState.corked, 'should be corked')
-          }, 40)
+      // Wait twice as long as the default bufferWindowTime
+      setTimeout(function () {
+        t.ok(client._writableState.corked, 'should be corked')
+      }, 40)
 
-          // Wait twice as long as the custom bufferWindowTime
-          setTimeout(function () {
-            t.notOk(client._writableState.corked, 'should be uncorked')
-            client.destroy()
-            server.close()
-            t.end()
-          }, 300)
-        })
-      })
+      // Wait twice as long as the custom bufferWindowTime
+      setTimeout(function () {
+        t.notOk(client._writableState.corked, 'should be uncorked')
+        client.destroy()
+        server.close()
+        t.end()
+      }, 300)
     })
   })
 
@@ -102,22 +93,20 @@ dataTypes.forEach(function (dataType) {
     const server = APMServer(function (req, res) {
       t.fail('should not send anything to the APM Server')
     }).client({ bufferWindowSize: 1 }, function (client) {
-      client.on('cloud-metadata', function () {
-        client.on('error', function (err) {
-          t.error(err)
-        })
-
-        client[sendFn]({ req: 1 })
-        client[sendFn]({ req: 2 })
-
-        // Destroy the client before the _writev function have a chance to be called
-        client.destroy()
-
-        setTimeout(function () {
-          server.close()
-          t.end()
-        }, 10)
+      client.on('error', function (err) {
+        t.error(err)
       })
+
+      client[sendFn]({ req: 1 })
+      client[sendFn]({ req: 2 })
+
+      // Destroy the client before the _writev function have a chance to be called
+      client.destroy()
+
+      setTimeout(function () {
+        server.close()
+        t.end()
+      }, 10)
     })
   })
 })


### PR DESCRIPTION
These provide a mechanism for the Node.js APM Agent to pass in metadata
asynchronously and be sure that the client will not begin an intake
request until that metadata is provided.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/2404