### PR TITLE
feat: Add APM Server version fetching and client.supportsKeepingUnsampledTransaction()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # elastic-apm-http-client changelog
 
+## v10.4.0
+
+- Add APM Server version checking to the client. On creation the client will
+  call the [APM Server Information API](https://www.elastic.co/guide/en/apm/server/current/server-info.html)
+  to get the server version and save that.
+
+  The new `Client#supportsKeepingUnsampledTransaction()` boolean method returns
+  `true` if APM Server is a version that requires unsampled transactions to
+  be sent. This will be used by the APM Agent to [drop unsampled transactions
+  for newer APM Servers](https://github.com/elastic/apm-agent-nodejs/issues/2455).
+
+  There is a new `apmServerVersion: <string>` config option to tell the Client
+  to skip fetching the APM Server version and use the given value. This config
+  option is intended mainly for internal test suite usage.
+
 ## v10.3.0
 
 - Add the `expectExtraMetadata: true` configuration option and

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Data sanitizing configuration:
   the following properties: `error.exception.message` and `error.log.message`.
   (default: `2048`)
 
-Debug options:
+Debug/Test options:
 
 - `logger` - A [pino](https://getpino.io) logger to use for trace and
   debug-level logging.
@@ -198,6 +198,10 @@ Debug options:
   sent to the APM Server should be written. The data will be in ndjson
   format and will be uncompressed. Note that using this option can
   impact performance.
+- `apmServerVersion` - A string version to assume is the version of the
+  APM Server at `serverUrl`. This option is typically only used for testing.
+  Normally this client will fetch the APM Server version at startup.
+  XXX
 
 ### Event: `config`
 
@@ -280,6 +284,15 @@ configuration options can be updated except:
 - `maxSockets`
 - `maxFreeSockets`
 - `centralConfig`
+
+### `client.supportsKeepingUnsampledTransaction()`
+
+This method returns a boolean indicating whether the remote APM Server (per
+the configured `serverUrl`) is of a version that requires unsampled transactions
+to be sent.
+
+This defaults to `true` if the remote APM server version is not yet known. The
+client will query the APM server for its version in the background.
 
 ### `client.addMetadataFilter(fn)`
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Data sanitizing configuration:
   the following properties: `error.exception.message` and `error.log.message`.
   (default: `2048`)
 
-Debug/Test options:
+Other options:
 
 - `logger` - A [pino](https://getpino.io) logger to use for trace and
   debug-level logging.
@@ -200,8 +200,8 @@ Debug/Test options:
   impact performance.
 - `apmServerVersion` - A string version to assume is the version of the
   APM Server at `serverUrl`. This option is typically only used for testing.
-  Normally this client will fetch the APM Server version at startup.
-  XXX
+  Normally this client will fetch the APM Server version at startup via a
+  `GET /` request. Setting this option avoids that request.
 
 ### Event: `config`
 
@@ -291,8 +291,9 @@ This method returns a boolean indicating whether the remote APM Server (per
 the configured `serverUrl`) is of a version that requires unsampled transactions
 to be sent.
 
-This defaults to `true` if the remote APM server version is not yet known. The
-client will query the APM server for its version in the background.
+This defaults to `true` if the remote APM server version is not known -- either
+because the background fetch of the APM Server version hasn't yet completed,
+or the version could not be fetched.
 
 ### `client.addMetadataFilter(fn)`
 

--- a/index.js
+++ b/index.js
@@ -1054,7 +1054,6 @@ Client.prototype._fetchApmServerVersion = function () {
 
   const setVerUnknownAndNotify = (errmsg) => {
     self._apmServerVersion = null // means "unknown version"
-    self.emit('request-error', new Error(errmsg))
     if (isLambdaExecutionEnvironment) {
       // In a Lambda environment, where the process can be frozen, it is not
       // unusual for this request to hit an error. As long as APM Server version

--- a/index.js
+++ b/index.js
@@ -1028,7 +1028,7 @@ function getChoppedStreamHandler (client, onerror) {
  * Some behaviors in the APM depend on the APM Server version. These are
  * exposed as `Client#supports...` boolean methods.
  *
- * These `Client#supports...` property names intentionally match those from the Java agent:
+ * These `Client#supports...` method names intentionally match those from the Java agent:
  * https://github.com/elastic/apm-agent-java/blob/master/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java#L322-L349
  */
 Client.prototype.supportsKeepingUnsampledTransaction = function () {
@@ -1044,10 +1044,10 @@ Client.prototype.supportsKeepingUnsampledTransaction = function () {
 
 /**
  * Fetch the APM Server version and set `this._apmServerVersion`.
+ * https://www.elastic.co/guide/en/apm/server/current/server-info.html
+ *
  * If fetching/parsing fails then the APM server version will be set to `null`
  * to indicate "unknown version".
- *
- * This request must not keep the process open.
  */
 Client.prototype._fetchApmServerVersion = function () {
   const self = this
@@ -1080,6 +1080,11 @@ Client.prototype._fetchApmServerVersion = function () {
       chunks.push(chunk)
     })
     res.on('end', function () {
+      if (chunks.length === 0) {
+        emitErrorAndSetUnknown('APM Server information endpoint returned no body, often this indicates authentication ("apiKey" or "secretToken") is incorrect')
+        return
+      }
+
       let serverInfo
       try {
         serverInfo = JSON.parse(Buffer.concat(chunks))

--- a/index.js
+++ b/index.js
@@ -1050,18 +1050,16 @@ Client.prototype.supportsKeepingUnsampledTransaction = function () {
  * to indicate "unknown version".
  */
 Client.prototype._fetchApmServerVersion = function () {
-  const self = this
-
   const setVerUnknownAndNotify = (errmsg) => {
-    self._apmServerVersion = null // means "unknown version"
+    this._apmServerVersion = null // means "unknown version"
     if (isLambdaExecutionEnvironment) {
       // In a Lambda environment, where the process can be frozen, it is not
       // unusual for this request to hit an error. As long as APM Server version
       // fetching is not critical to tracing of Lambda invocations, then it is
       // preferable to not add an error message to the users log.
-      self._log.debug('verfetch: ' + errmsg)
+      this._log.debug('verfetch: ' + errmsg)
     } else {
-      self.emit('request-error', new Error(errmsg))
+      this.emit('request-error', new Error(errmsg))
     }
   }
   const headers = getHeaders(this._conf)
@@ -1084,10 +1082,10 @@ Client.prototype._fetchApmServerVersion = function () {
     }
 
     const chunks = []
-    res.on('data', function (chunk) {
+    res.on('data', chunk => {
       chunks.push(chunk)
     })
-    res.on('end', function () {
+    res.on('end', () => {
       if (chunks.length === 0) {
         setVerUnknownAndNotify('APM Server information endpoint returned no body, often this indicates authentication ("apiKey" or "secretToken") is incorrect')
         return
@@ -1105,12 +1103,12 @@ Client.prototype._fetchApmServerVersion = function () {
         // APM Server 7.0.0 dropped the "ok"-level in the info endpoint body.
         const verStr = serverInfo.ok ? serverInfo.ok.version : serverInfo.version
         try {
-          self._apmServerVersion = semver.SemVer(verStr)
+          this._apmServerVersion = semver.SemVer(verStr)
         } catch (verErr) {
           setVerUnknownAndNotify(`could not parse APM Server version "${verStr}": ${verErr.message}`)
           return
         }
-        self._log.debug({ apmServerVersion: verStr }, 'fetched APM Server version')
+        this._log.debug({ apmServerVersion: verStr }, 'fetched APM Server version')
       } else {
         setVerUnknownAndNotify(`could not determine APM Server version from information endpoint body: ${JSON.stringify(serverInfo)}`)
       }
@@ -1122,7 +1120,7 @@ Client.prototype._fetchApmServerVersion = function () {
     socket.unref()
   })
   req.on('timeout', () => {
-    self._log.trace('_fetchApmServerVersion timeout')
+    this._log.trace('_fetchApmServerVersion timeout')
     req.destroy(new Error(`timeout (${reqOpts.timeout}ms) fetching APM Server version`))
   })
   req.on('error', err => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "fast-stream-to-buffer": "^1.0.0",
     "object-filter-sequence": "^1.0.0",
     "readable-stream": "^3.4.0",
+    "semver": "^6.3.0",
     "stream-chopper": "^3.0.1"
   },
   "devDependencies": {
     "ndjson": "^1.5.0",
     "nyc": "^14.1.1",
-    "semver": "^6.3.0",
     "standard": "^14.3.1",
     "tape": "^4.11.0"
   },

--- a/test/abort.test.js
+++ b/test/abort.test.js
@@ -54,7 +54,7 @@ test('abort request if server responds early', function (t) {
     } else {
       t.fail('should not get more than two requests')
     }
-  }).client(function (_client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (_client) {
     client = _client
     client.sendSpan({ foo: 1 })
     client.on('request-error', function (err) {

--- a/test/apm-server-version.test.js
+++ b/test/apm-server-version.test.js
@@ -1,0 +1,142 @@
+'use strict'
+
+// Test that fetching the APM Server version works as expected.
+//
+// Notes:
+// - Testing that the APM Server version fetch request does not hold the
+//   process open is tested in "side-effects.test.js".
+
+const test = require('tape')
+const { APMServer, validOpts } = require('./lib/utils')
+const Client = require('../')
+
+test('no APM server version fetch if apmServerVersion is given', function (t) {
+  t.plan(1)
+  const server = APMServer(function (req, res) {
+    t.fail(`there should not be an APM server request: ${req.method} ${req.url}`)
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
+    setTimeout(() => {
+      t.pass('made it to timeout with no APM server request')
+      server.close()
+      client.destroy()
+      t.end()
+    }, 100)
+  })
+})
+
+test('APM server version fetch works for "6.6.0"', function (t) {
+  const server = APMServer(function (req, res) {
+    t.equal(req.method, 'GET')
+    t.equal(req.url, '/', 'got APM Server information API request')
+
+    res.writeHead(200)
+    const verInfo = {
+      build_date: '2021-09-16T02:05:39Z',
+      build_sha: 'a183f675ecd03fca4a897cbe85fda3511bc3ca43',
+      version: '6.6.0'
+    }
+    // Pre-7.0.0 versions of APM Server responded with this body:
+    res.end(JSON.stringify({ ok: verInfo }))
+  }).client({}, function (client) {
+    t.strictEqual(client._apmServerVersion, undefined,
+      'client._apmServerVersion is undefined immediately after client creation')
+    t.equal(client.supportsKeepingUnsampledTransaction(), true,
+      'client.supportsKeepingUnsampledTransaction() defaults to true before fetch')
+
+    // Currently there isn't a mechanism to wait for the fetch request, so for
+    // now just wait a bit.
+    setTimeout(() => {
+      t.ok(client._apmServerVersion, 'client._apmServerVersion is set')
+      t.equal(client._apmServerVersion.toString(), '6.6.0')
+      t.equal(client.supportsKeepingUnsampledTransaction(), true,
+        'client.supportsKeepingUnsampledTransaction() is true after fetch')
+
+      server.close()
+      client.destroy()
+      t.end()
+    }, 200)
+  })
+})
+
+test('APM server version fetch works for "7.16.0"', function (t) {
+  const server = APMServer(function (req, res) {
+    t.equal(req.method, 'GET')
+    t.equal(req.url, '/', 'got APM Server information API request')
+
+    res.writeHead(200)
+    const verInfo = {
+      build_date: '2021-09-16T02:05:39Z',
+      build_sha: 'a183f675ecd03fca4a897cbe85fda3511bc3ca43',
+      version: '7.16.0'
+    }
+    res.end(JSON.stringify(verInfo, null, 2))
+  }).client({}, function (client) {
+    t.strictEqual(client._apmServerVersion, undefined,
+      'client._apmServerVersion is undefined immediately after client creation')
+    t.equal(client.supportsKeepingUnsampledTransaction(), true,
+      'client.supportsKeepingUnsampledTransaction() defaults to true before fetch')
+
+    // Currently there isn't a mechanism to wait for the fetch request, so for
+    // now just wait a bit.
+    setTimeout(() => {
+      t.ok(client._apmServerVersion, 'client._apmServerVersion is set')
+      t.equal(client._apmServerVersion.toString(), '7.16.0')
+      t.equal(client.supportsKeepingUnsampledTransaction(), true,
+        'client.supportsKeepingUnsampledTransaction() is true after fetch')
+
+      server.close()
+      client.destroy()
+      t.end()
+    }, 200)
+  })
+})
+
+test('APM server version fetch works for "8.0.0"', function (t) {
+  const server = APMServer(function (req, res) {
+    t.equal(req.method, 'GET')
+    t.equal(req.url, '/', 'got APM Server information API request')
+
+    res.writeHead(200)
+    const verInfo = {
+      build_date: '2021-09-16T02:05:39Z',
+      build_sha: 'a183f675ecd03fca4a897cbe85fda3511bc3ca43',
+      version: '8.0.0'
+    }
+    res.end(JSON.stringify(verInfo, null, 2))
+  }).client({}, function (client) {
+    t.strictEqual(client._apmServerVersion, undefined,
+      'client._apmServerVersion is undefined immediately after client creation')
+    t.equal(client.supportsKeepingUnsampledTransaction(), true,
+      'client.supportsKeepingUnsampledTransaction() defaults to true before fetch')
+
+    // Currently there isn't a mechanism to wait for the fetch request, so for
+    // now just wait a bit.
+    setTimeout(() => {
+      t.ok(client._apmServerVersion, 'client._apmServerVersion is set')
+      t.equal(client._apmServerVersion.toString(), '8.0.0')
+      t.equal(client.supportsKeepingUnsampledTransaction(), false,
+        'client.supportsKeepingUnsampledTransaction() is false after fetch')
+
+      server.close()
+      client.destroy()
+      t.end()
+    }, 200)
+  })
+})
+
+test('APM server version is null on fetch error', function (t) {
+  const client = new Client(validOpts({
+    serverUrl: 'http://localhost:62345' // hopefully some unused port
+  }))
+  client.on('request-error', err => {
+    t.ok(err, 'got a "request-error" event')
+    t.ok(/error fetching APM Server version/.test(err.message),
+      'error message is about APM Server version fetching')
+    t.strictEqual(client._apmServerVersion, null, 'client._apmServerVersion')
+    t.equal(client.supportsKeepingUnsampledTransaction(), true,
+      'client.supportsKeepingUnsampledTransaction() defaults to true after failed fetch')
+
+    client.destroy()
+    t.end()
+  })
+})

--- a/test/apm-server-version.test.js
+++ b/test/apm-server-version.test.js
@@ -125,8 +125,9 @@ test('APM server version fetch works for "8.0.0"', function (t) {
 })
 
 test('APM server version is null on fetch error', function (t) {
+  const HOPEFULLY_UNUSED_PORT_HACK = 62345
   const client = new Client(validOpts({
-    serverUrl: 'http://localhost:62345' // hopefully some unused port
+    serverUrl: 'http://localhost:' + HOPEFULLY_UNUSED_PORT_HACK
   }))
   client.on('request-error', err => {
     t.ok(err, 'got a "request-error" event')

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -38,7 +38,7 @@ dataTypes.forEach(function (dataType) {
         server.close()
         t.end()
       })
-    }).client(function (client) {
+    }).client({ apmServerVersion: '8.0.0' }, function (client) {
       client[sendFn]({ foo: 42 })
       client.flush(() => { client.destroy() })
     })
@@ -59,7 +59,7 @@ dataTypes.forEach(function (dataType) {
       req.on('end', function () {
         res.end()
       })
-    }).client(function (client) {
+    }).client({ apmServerVersion: '8.0.0' }, function (client) {
       let nexttick = false
       client[sendFn]({ foo: 42 }, function () {
         t.ok(nexttick, 'should call callback')
@@ -92,7 +92,7 @@ dataTypes.forEach(function (dataType) {
         client.destroy()
         t.end()
       })
-    }).client(function (client_) {
+    }).client({ apmServerVersion: '8.0.0' }, function (client_) {
       client = client_
       client[sendFn]({ foo: 42 })
       client.end()
@@ -118,7 +118,7 @@ dataTypes.forEach(function (dataType) {
         client.destroy()
         t.end()
       })
-    }).client({ time: 100 }, function (client_) {
+    }).client({ time: 100, apmServerVersion: '8.0.0' }, function (client_) {
       client = client_
       client[sendFn]({ foo: 42 })
     })
@@ -145,7 +145,7 @@ dataTypes.forEach(function (dataType) {
         client.destroy()
         t.end()
       })
-    }).client({ time: 100 }, function (client_) {
+    }).client({ time: 100, apmServerVersion: '8.0.0' }, function (client_) {
       client = client_
       client[sendFn]({ req: 1 })
       client[sendFn]({ req: 2 })
@@ -189,7 +189,7 @@ dataTypes.forEach(function (dataType) {
           t.end()
         }
       })
-    }).client({ time: 100 }, function (_client) {
+    }).client({ time: 100, apmServerVersion: '8.0.0' }, function (_client) {
       client = _client
       send()
     })
@@ -220,7 +220,7 @@ test('client.flush(callback) - with active request', function (t) {
     req.on('end', function () {
       res.end()
     })
-  }).client({ bufferWindowTime: -1 }, function (client) {
+  }).client({ bufferWindowTime: -1, apmServerVersion: '8.0.0' }, function (client) {
     t.equal(client._active, false, 'no outgoing HTTP request to begin with')
     client.sendSpan({ foo: 42 })
     t.equal(client._active, true, 'an outgoing HTTP request should be active')
@@ -252,7 +252,7 @@ test('client.flush(callback) - with queued request', function (t) {
     req.on('end', function () {
       res.end()
     })
-  }).client({ bufferWindowTime: -1 }, function (client) {
+  }).client({ bufferWindowTime: -1, apmServerVersion: '8.0.0' }, function (client) {
     client.sendSpan({ req: 1 })
     client.flush()
     client.sendSpan({ req: 2 })
@@ -289,7 +289,7 @@ test('2nd flush before 1st flush have finished', function (t) {
       requestEnds++
       res.end()
     })
-  }).client({ bufferWindowTime: -1 }, function (client) {
+  }).client({ bufferWindowTime: -1, apmServerVersion: '8.0.0' }, function (client) {
     client.sendSpan({ req: 1 })
     client.flush()
     client.sendSpan({ req: 2 })
@@ -322,7 +322,7 @@ test('client.end(callback)', function (t) {
       client.destroy()
       t.end()
     })
-  }).client(function (client_) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client_) {
     client = client_
     client.sendSpan({ foo: 42 })
     client.end(function () {
@@ -339,7 +339,7 @@ test('client.sent', function (t) {
     req.on('end', function () {
       res.end()
     })
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({ foo: 42 })
     client.sendSpan({ foo: 42 })
     client.sendTransaction({ foo: 42 })
@@ -380,7 +380,7 @@ test('should not open new request until it\'s needed after flush', function (t) 
         setTimeout(sendData, 250)
       }
     })
-  }).client(function (_client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (_client) {
     client = _client
     sendData()
   })
@@ -412,7 +412,7 @@ test('should not open new request until it\'s needed after timeout', function (t
         setTimeout(sendData, 250)
       }
     })
-  }).client({ time: 1 }, function (_client) {
+  }).client({ time: 1, apmServerVersion: '8.0.0' }, function (_client) {
     client = _client
     sendData()
   })

--- a/test/central-config.test.js
+++ b/test/central-config.test.js
@@ -99,7 +99,7 @@ test('polling', function (t) {
       default:
         t.fail('too many request')
     }
-  }).client({ centralConfig: true }, function (_client) {
+  }).client({ centralConfig: true, apmServerVersion: '8.0.0' }, function (_client) {
     client = _client
     client.on('config', function (conf) {
       t.equal(reqs, 6, 'should emit config after 6th request')

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -73,7 +73,8 @@ test('no secretToken or apiKey', function (t) {
   })
   server.listen(function () {
     client = new Client(validOpts({
-      serverUrl: 'http://localhost:' + server.address().port
+      serverUrl: 'http://localhost:' + server.address().port,
+      apmServerVersion: '8.0.0'
     }))
     client.sendSpan({ foo: 42 })
     client.end()
@@ -93,7 +94,8 @@ test('has apiKey', function (t) {
   server.listen(function () {
     client = new Client(validOpts({
       serverUrl: 'http://localhost:' + server.address().port,
-      apiKey: 'FooBar123'
+      apiKey: 'FooBar123',
+      apmServerVersion: '8.0.0'
     }))
     client.sendSpan({ foo: 42 })
     client.end()
@@ -115,7 +117,8 @@ test('custom headers', function (t) {
       serverUrl: 'http://localhost:' + server.address().port,
       headers: {
         'X-Foo': 'bar'
-      }
+      },
+      apmServerVersion: '8.0.0'
     }))
     client.sendSpan({ foo: 42 })
     client.end()
@@ -125,7 +128,8 @@ test('custom headers', function (t) {
 test('serverUrl is invalid', function (t) {
   t.throws(function () {
     new Client(validOpts({ // eslint-disable-line no-new
-      serverUrl: 'invalid'
+      serverUrl: 'invalid',
+      apmServerVersion: '8.0.0'
     }))
   })
   t.end()
@@ -142,7 +146,8 @@ test('serverUrl contains path', function (t) {
     t.end()
   }).listen(function () {
     client = new Client(validOpts({
-      serverUrl: 'http://localhost:' + server.address().port + '/subpath'
+      serverUrl: 'http://localhost:' + server.address().port + '/subpath',
+      apmServerVersion: '8.0.0'
     }))
     client.sendSpan({ foo: 42 })
     client.end()
@@ -153,7 +158,7 @@ test('reject unauthorized TLS by default', function (t) {
   t.plan(3)
   const server = APMServer({ secure: true }, function (req, res) {
     t.fail('should should not get request')
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'self signed certificate')
@@ -175,7 +180,7 @@ test('allow unauthorized TLS if asked', function (t) {
     client.destroy()
     server.close()
     t.end()
-  }).client({ rejectUnauthorized: false }, function (client_) {
+  }).client({ rejectUnauthorized: false, apmServerVersion: '8.0.0' }, function (client_) {
     client = client_
     client.sendSpan({ foo: 42 })
     client.end()
@@ -192,7 +197,7 @@ test('allow self-signed TLS certificate by specifying the CA', function (t) {
     server.close()
     t.end()
   })
-  server.client({ serverCaCert: server.cert }, function (client_) {
+  server.client({ serverCaCert: server.cert, apmServerVersion: '8.0.0' }, function (client_) {
     client = client_
     client.sendSpan({ foo: 42 })
     client.end()
@@ -217,7 +222,8 @@ test('metadata', function (t) {
       doesNotNest: {
         nope: 'this should be [object Object]'
       }
-    }
+    },
+    apmServerVersion: '8.0.0' // avoid the APM server version fetch request
   }
   const server = APMServer(function (req, res) {
     req = processIntakeReq(req)
@@ -305,7 +311,8 @@ test('metadata - default values', function (t) {
   const opts = {
     agentName: 'custom-agentName',
     agentVersion: 'custom-agentVersion',
-    serviceName: 'custom-serviceName'
+    serviceName: 'custom-serviceName',
+    apmServerVersion: '8.0.0' // avoid the APM server version fetch request
   }
   const server = APMServer(function (req, res) {
     req = processIntakeReq(req)
@@ -400,7 +407,7 @@ test('metadata - container info', function (t) {
       server.close()
       t.end()
     })
-  }).client({}, function (client_) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client_) {
     client = client_
     client.sendSpan({ foo: 42 })
     client.end()
@@ -421,7 +428,7 @@ test('agentName', function (t) {
       server.close()
       t.end()
     })
-  }).client({ serviceName: 'custom' }, function (client_) {
+  }).client({ serviceName: 'custom', apmServerVersion: '8.0.0' }, function (client_) {
     client = client_
     client.sendSpan({ foo: 42 })
     client.end()
@@ -466,7 +473,7 @@ test('payloadLogFile', function (t) {
         })
       }
     })
-  }).client({ payloadLogFile: filename }, function (client_) {
+  }).client({ payloadLogFile: filename, apmServerVersion: '8.0.0' }, function (client_) {
     client = client_
     client.sendTransaction({ req: 1 })
     client.sendSpan({ req: 2 })
@@ -490,7 +497,7 @@ test('update conf', function (t) {
       server.close()
       t.end()
     })
-  }).client({ serviceName: 'foo' }, function (client_) {
+  }).client({ serviceName: 'foo', apmServerVersion: '8.0.0' }, function (client_) {
     client = client_
     client.config({ serviceName: 'bar' })
     client.sendSpan({ foo: 42 })
@@ -536,7 +543,8 @@ test('503 response from apm-server for central config should not crash', functio
       // Turn centralConfig *off*. We'll manually trigger a poll for central
       // config via internal methods, so that we don't need to muck with
       // internal `setTimeout` intervals.
-      centralConfig: false
+      centralConfig: false,
+      apmServerVersion: '8.0.0'
     }))
 
     // 2. Ensure the client conditions for the crash.

--- a/test/edge-cases.test.js
+++ b/test/edge-cases.test.js
@@ -27,7 +27,8 @@ test('Event: close - if chopper ends', function (t) {
     }, 10)
   }).listen(function () {
     client = new Client(validOpts({
-      serverUrl: 'http://localhost:' + server.address().port
+      serverUrl: 'http://localhost:' + server.address().port,
+      apmServerVersion: '8.0.0'
     }))
 
     client.on('finish', function () {
@@ -53,7 +54,8 @@ test('Event: close - if chopper is destroyed', function (t) {
     }, 10)
   }).listen(function () {
     client = new Client(validOpts({
-      serverUrl: 'http://localhost:' + server.address().port
+      serverUrl: 'http://localhost:' + server.address().port,
+      apmServerVersion: '8.0.0'
     }))
 
     client.on('finish', function () {
@@ -71,7 +73,7 @@ test('write after end', function (t) {
   t.plan(2)
   const server = APMServer(function (req, res) {
     t.fail('should never get any request')
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'write after end')
@@ -87,7 +89,7 @@ test('request with error - no body', function (t) {
   const server = APMServer(function (req, res) {
     res.statusCode = 418
     res.end()
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'Unexpected APM Server response')
@@ -108,7 +110,7 @@ test('request with error - non json body', function (t) {
   const server = APMServer(function (req, res) {
     res.statusCode = 418
     res.end('boom!')
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'Unexpected APM Server response')
@@ -130,7 +132,7 @@ test('request with error - invalid json body', function (t) {
     res.statusCode = 418
     res.setHeader('Content-Type', 'application/json')
     res.end('boom!')
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'Unexpected APM Server response')
@@ -153,7 +155,7 @@ test('request with error - json body without accepted or errors properties', fun
     res.statusCode = 418
     res.setHeader('Content-Type', 'application/json')
     res.end(body)
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'Unexpected APM Server response')
@@ -175,7 +177,7 @@ test('request with error - json body with accepted and errors properties', funct
     res.statusCode = 418
     res.setHeader('Content-Type', 'application/json')
     res.end(JSON.stringify({ accepted: 42, errors: [{ message: 'bar' }] }))
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'Unexpected APM Server response')
@@ -197,7 +199,7 @@ test('request with error - json body where Content-Type contains charset', funct
     res.statusCode = 418
     res.setHeader('Content-Type', 'application/json; charset=utf-8')
     res.end(JSON.stringify({ accepted: 42, errors: [{ message: 'bar' }] }))
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       t.equal(err.message, 'Unexpected APM Server response')
@@ -217,7 +219,7 @@ test('request with error - json body where Content-Type contains charset', funct
 test('socket hang up', function (t) {
   const server = APMServer(function (req, res) {
     req.socket.destroy()
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     let closed = false
     client.on('request-error', function (err) {
       t.equal(err.message, 'socket hang up')
@@ -269,7 +271,7 @@ test('socket hang up - continue with new request', function (t) {
       res.end()
       client.end() // cleanup 1: end the client stream so it can 'finish'
     })
-  }).client(function (_client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (_client) {
     client = _client
     client.on('request-error', function (err) {
       t.equal(err.message, 'socket hang up', 'got "socket hang up" request-error')
@@ -290,7 +292,8 @@ test('intakeResTimeoutOnEnd', function (t) {
   const server = APMServer(function (req, res) {
     req.resume()
   }).client({
-    intakeResTimeoutOnEnd: 500
+    intakeResTimeoutOnEnd: 500,
+    apmServerVersion: '8.0.0'
   }, function (client) {
     const start = Date.now()
     client.on('request-error', function (err) {
@@ -311,7 +314,8 @@ test('intakeResTimeout', function (t) {
   const server = APMServer(function (req, res) {
     req.resume()
   }).client({
-    intakeResTimeout: 400
+    intakeResTimeout: 400,
+    apmServerVersion: '8.0.0'
   }, function (client) {
     const start = Date.now()
     client.on('request-error', function (err) {
@@ -335,7 +339,8 @@ test('socket timeout - server response too slow', function (t) {
   }).client({
     serverTimeout: 1000,
     // Set the intake res timeout higher to be able to test serverTimeout.
-    intakeResTimeoutOnEnd: 5000
+    intakeResTimeoutOnEnd: 5000,
+    apmServerVersion: '8.0.0'
   }, function (client) {
     const start = Date.now()
     client.on('request-error', function (err) {
@@ -358,7 +363,7 @@ test('socket timeout - client request too slow', function (t) {
     req.on('end', function () {
       res.end()
     })
-  }).client({ serverTimeout: 1000 }, function (client) {
+  }).client({ serverTimeout: 1000, apmServerVersion: '8.0.0' }, function (client) {
     const start = Date.now()
     client.on('request-error', function (err) {
       const end = Date.now()
@@ -409,7 +414,8 @@ test('client.destroy() - on ended client', function (t) {
 
   server.listen(function () {
     client = new Client(validOpts({
-      serverUrl: 'http://localhost:' + server.address().port
+      serverUrl: 'http://localhost:' + server.address().port,
+      apmServerVersion: '8.0.0'
     }))
     client.on('finish', function () {
       t.pass('should emit finish only once')
@@ -556,7 +562,7 @@ dataTypes.forEach(function (dataType) {
         server.close()
         t.end()
       })
-    }).client(function (client) {
+    }).client({ apmServerVersion: '8.0.0' }, function (client) {
       const obj = { foo: 42 }
       obj.bar = obj
       client[sendFn](obj)

--- a/test/expectExtraMetadata.test.js
+++ b/test/expectExtraMetadata.test.js
@@ -20,7 +20,7 @@ test('expectExtraMetadata and setExtraMetadata used properly', function (t) {
       res.statusCode = 202
       res.end()
     })
-  }).client({ expectExtraMetadata: true }, function (client) {
+  }).client({ expectExtraMetadata: true, apmServerVersion: '8.0.0' }, function (client) {
     client.setExtraMetadata({
       foo: 'bar',
       service: {
@@ -58,7 +58,7 @@ test('empty setExtraMetadata is fine, and calling after send* is fine', function
       res.statusCode = 202
       res.end()
     })
-  }).client({ expectExtraMetadata: true }, function (client) {
+  }).client({ expectExtraMetadata: true, apmServerVersion: '8.0.0' }, function (client) {
     client.sendTransaction({ req: 1 })
     client.setExtraMetadata()
 
@@ -77,7 +77,7 @@ test('empty setExtraMetadata is fine, and calling after send* is fine', function
 test('expectExtraMetadata:true with *no* setExtraMetadata call results in a corked client', function (t) {
   const server = APMServer(function (req, res) {
     t.fail('do NOT expect to get intake request to APM server')
-  }).client({ expectExtraMetadata: true }, function (client) {
+  }).client({ expectExtraMetadata: true, apmServerVersion: '8.0.0' }, function (client) {
     // Explicitly *not* calling setExtraMetadata().
     client.sendTransaction({ req: 1 })
 

--- a/test/k8s.test.js
+++ b/test/k8s.test.js
@@ -18,7 +18,7 @@ test('no environment variables', function (t) {
       server.close()
       t.end()
     })
-  }).client(function (client) {
+  }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -37,7 +37,7 @@ test('kubernetesNodeName only', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesNodeName: 'foo' }, function (client) {
+  }).client({ kubernetesNodeName: 'foo', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -56,7 +56,7 @@ test('kubernetesNamespace only', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesNamespace: 'foo' }, function (client) {
+  }).client({ kubernetesNamespace: 'foo', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -75,7 +75,7 @@ test('kubernetesPodName only', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesPodName: 'foo' }, function (client) {
+  }).client({ kubernetesPodName: 'foo', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -94,7 +94,7 @@ test('kubernetesPodUID only', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesPodUID: 'foo' }, function (client) {
+  }).client({ kubernetesPodUID: 'foo', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -117,7 +117,7 @@ test('all', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodName: 'baz', kubernetesPodUID: 'qux' }, function (client) {
+  }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodName: 'baz', kubernetesPodUID: 'qux', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -139,7 +139,7 @@ test('all except kubernetesNodeName', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesNamespace: 'bar', kubernetesPodName: 'baz', kubernetesPodUID: 'qux' }, function (client) {
+  }).client({ kubernetesNamespace: 'bar', kubernetesPodName: 'baz', kubernetesPodUID: 'qux', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -161,7 +161,7 @@ test('all except kubernetesNamespace', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesNodeName: 'foo', kubernetesPodName: 'baz', kubernetesPodUID: 'qux' }, function (client) {
+  }).client({ kubernetesNodeName: 'foo', kubernetesPodName: 'baz', kubernetesPodUID: 'qux', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -184,7 +184,7 @@ test('all except kubernetesPodName', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodUID: 'qux' }, function (client) {
+  }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodUID: 'qux', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })
@@ -207,7 +207,7 @@ test('all except kubernetesPodUID', function (t) {
       server.close()
       t.end()
     })
-  }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodName: 'baz' }, function (client) {
+  }).client({ kubernetesNodeName: 'foo', kubernetesNamespace: 'bar', kubernetesPodName: 'baz', apmServerVersion: '8.0.0' }, function (client) {
     client.sendError({})
     client.flush(() => { client.destroy() })
   })

--- a/test/lib/call-me-back-maybe.js
+++ b/test/lib/call-me-back-maybe.js
@@ -8,6 +8,7 @@
 //    handles. For this Client that means:
 //    - ensure no `_pollConfig` requests via `centralConfig: false`
 //    - do not provide a `cloudMetadataFetcher`
+//    - set `apmServerVersion` to not have an APM Server version fetch request
 // 2. There must be a listening APM server to which to send data.
 
 const Client = require('../../') // elastic-apm-http-client
@@ -21,7 +22,8 @@ const client = new Client({
   agentName: 'my-nodejs-agent',
   agentVersion: '1.2.3',
   userAgent: 'my-nodejs-agent/1.2.3',
-  centralConfig: false // important for repro, see above
+  centralConfig: false, // important for repro, see above
+  apmServerVersion: '8.0.0' // important for repro, see above
 })
 
 const e = { exception: { message: 'boom', type: 'Error' } }

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -33,17 +33,17 @@ function APMServer (opts, onreq) {
     socket.unref()
   })
 
-  server.client = function (opts, onclient) {
-    if (typeof opts === 'function') {
-      onclient = opts
-      opts = {}
+  server.client = function (clientOpts, onclient) {
+    if (typeof clientOpts === 'function') {
+      onclient = clientOpts
+      clientOpts = {}
     }
     server.listen(function () {
       onclient(new Client(validOpts(Object.assign({
         // logger: require('pino')({ level: 'trace' }), // uncomment for debugging
         serverUrl: `http${secure ? 's' : ''}://localhost:${server.address().port}`,
         secretToken: 'secret'
-      }, opts))))
+      }, clientOpts))))
     })
     return server
   }

--- a/test/metadata-filter.test.js
+++ b/test/metadata-filter.test.js
@@ -23,7 +23,7 @@ test('addMetadataFilter', function (t) {
     })
   })
 
-  server.client(function (client) {
+  server.client({ apmServerVersion: '8.0.0' }, function (client) {
     client.addMetadataFilter(function (md) {
       delete md.process.argv
       md.labels = { foo: 'bar' }

--- a/test/side-effects.test.js
+++ b/test/side-effects.test.js
@@ -24,6 +24,15 @@ test('client should not hold the process open', function (t) {
   ]
 
   const server = APMServer(function (req, res) {
+    // Handle the server info endpoint.
+    if (req.method === 'GET' && req.url === '/') {
+      req.resume()
+      res.statusCode = 200
+      res.end(JSON.stringify({ build_date: '...', build_sha: '...', version: '8.0.0' }))
+      return
+    }
+
+    // Handle an intake request.
     assertIntakeReq(t, req)
     req = processIntakeReq(req)
     req.on('data', function (obj) {
@@ -70,6 +79,14 @@ test('client should not hold the process open even if APM server not responding'
   ]
 
   const server = APMServer(function (req, res) {
+    // Handle the server info endpoint.
+    if (req.method === 'GET' && req.url === '/') {
+      req.resume()
+      // Intentionally do not respond.
+      return
+    }
+
+    // Handle an intake request.
     assertIntakeReq(t, req)
     req = processIntakeReq(req)
     req.on('data', function (obj) {
@@ -77,6 +94,7 @@ test('client should not hold the process open even if APM server not responding'
     })
     req.on('end', function () {
       res.statusCode = 202
+      // Here the server is intentionally not responding:
       // res.end()
       // server.close()
     })

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -53,7 +53,7 @@ dataTypes.forEach(function (dataType) {
           server.close()
           t.end()
         })
-      }).client(function (client) {
+      }).client({ apmServerVersion: '8.0.0' }, function (client) {
         client[sendFn]({
           context: {
             [prop]: {

--- a/test/truncate.test.js
+++ b/test/truncate.test.js
@@ -17,6 +17,7 @@ const options = [
 ]
 
 options.forEach(function (opts) {
+  const clientOpts = Object.assign({ apmServerVersion: '8.0.0' }, opts)
   const veryLong = 12000
   const lineLen = opts.truncateStringsAt || 1024
   const longFieldLen = opts.truncateLongFieldsAt || 10000
@@ -74,7 +75,7 @@ options.forEach(function (opts) {
         server.close()
         t.end()
       })
-    }).client(opts, function (client) {
+    }).client(clientOpts, function (client) {
       client.sendTransaction({
         id: 'abc123',
         name: genStr('a', veryLong),
@@ -153,7 +154,7 @@ options.forEach(function (opts) {
         server.close()
         t.end()
       })
-    }).client(opts, function (client) {
+    }).client(clientOpts, function (client) {
       client.sendSpan({
         id: 'abc123',
         name: genStr('a', veryLong),
@@ -216,7 +217,7 @@ options.forEach(function (opts) {
         server.close()
         t.end()
       })
-    }).client(opts, function (client) {
+    }).client(clientOpts, function (client) {
       client.sendSpan({
         id: 'abc123',
         name: 'cool-name',
@@ -302,7 +303,7 @@ options.forEach(function (opts) {
         server.close()
         t.end()
       })
-    }).client(opts, function (client) {
+    }).client(clientOpts, function (client) {
       client.sendError({
         id: 'abc123',
         log: {
@@ -385,7 +386,7 @@ options.forEach(function (opts) {
         server.close()
         t.end()
       })
-    }).client(opts, function (client) {
+    }).client(clientOpts, function (client) {
       client.sendMetricSet({
         timestamp: 1496170422281000,
         tags: {

--- a/test/writev.test.js
+++ b/test/writev.test.js
@@ -92,7 +92,7 @@ dataTypes.forEach(function (dataType) {
   test(`write on destroyed (${dataType})`, function (t) {
     const server = APMServer(function (req, res) {
       t.fail('should not send anything to the APM Server')
-    }).client({ bufferWindowSize: 1 }, function (client) {
+    }).client({ bufferWindowSize: 1, apmServerVersion: '8.0.0' }, function (client) {
       client.on('error', function (err) {
         t.error(err)
       })


### PR DESCRIPTION
This is to support the Node.js APM agent changing its behaviour based on
the APM Server version. Specifically whether to send or drop unsampled
transactions.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/2455
