### PR TITLE
feat: add support for Lambda data flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # elastic-apm-http-client changelog
 
+## v10.5.0
+
+- Add support for coordinating data flushing in an AWS Lambda environment. The
+  following two API additions are used to ensure that (a) the Elastic Lambda
+  extension is signaled at invocation end [per spec](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-aws-lambda.md#data-flushing)
+  and (b) a new intake request is not started when a Lambda function invocation
+  is not active.
+
+  - `Client#lambdaStart()` should be used to indicate when a Lambda function
+    invocation begins.
+  - `Client#flush([opts,] cb)` now supports an optional `opts.lambdaEnd`
+    boolean. Set it to true to indicate this is a flush at the end of a Lambda
+    function invocation.
+
 ## v10.4.0
 
 - Add APM Server version checking to the client. On creation the client will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # elastic-apm-http-client changelog
 
-## v10.5.0
+## v11.0.0
 
 - Add support for coordinating data flushing in an AWS Lambda environment. The
   following two API additions are used to ensure that (a) the Elastic Lambda
@@ -13,6 +13,11 @@
   - `Client#flush([opts,] cb)` now supports an optional `opts.lambdaEnd`
     boolean. Set it to true to indicate this is a flush at the end of a Lambda
     function invocation.
+
+  This is a **BREAKING CHANGE**, because current versions of elastic-apm-node
+  depend on `^10.4.0`. If this were released as another 10.x, then usage of
+  current elastic-apm-node with this version of the client would break
+  behavior in a Lambda environment.
 
 ## v10.4.0
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,33 @@ is provided. For example, in an AWS Lambda function some metadata is not
 available until the first function invocation -- which is some async time after
 Client creation.
 
+### `client.lambdaStart()`
+
+Tells the client that a Lambda function invocation has started.
+
+#### Notes on Lambda usage
+
+To properly handle [data flushing for instrumented Lambda functions](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-aws-lambda.md#data-flushing)
+this Client should be used as follows in a Lambda environment.
+
+- When a Lambda invocation starts, `client.lambdaStart()` must be called.
+
+  The Client prevents intake requests to APM Server when in a Lambda environment
+  when a function invocation is *not* active. This is to ensure that an intake
+  request does not accidentally span a period when a Lambda VM is frozen,
+  which can lead to timeouts and lost APM data.
+
+- When a Lambda invocation finishes, `client.flush({lambdaEnd: true}, cb)` must
+  be called.
+
+  The `lambdaEnd: true` tells the Client to (a) mark the lambda as inactive so
+  a subsequent intake request is not started until the next invocation, and
+  (b) signal the Elastic AWS Lambda Extension the this invocation is done.
+  The user's Lambda handler should not finish until `cb` is called. This
+  ensures that the extension receives tracing data and the end signal before
+  the Lambda Runtime freezes the VM.
+
+
 ### `client.sendSpan(span[, callback])`
 
 Send a span to the APM Server.
@@ -381,7 +408,7 @@ Arguments:
 - `callback` - Callback is called when the `metricset` have been flushed to
   the underlying system
 
-### `client.flush([callback])`
+### `client.flush([opts,] [callback])`
 
 Flush the internal buffer and end the current HTTP request to the APM
 Server. If no HTTP request is in process nothing happens. In an AWS Lambda
@@ -390,6 +417,11 @@ because the APM agent always flushes at the end of a Lambda handler.
 
 Arguments:
 
+- `opts`:
+  - `opts.lambdaEnd` - An optional boolean to indicate if this is the final
+    flush at the end of the Lambda function invocation. The client will do
+    some extra handling if this is the case. See notes in `client.lambdaStart()`
+    above.
 - `callback` - Callback is called when the internal buffer has been
   flushed and the HTTP request ended. If no HTTP request is in progress
   the callback is called in the next tick.

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ this Client should be used as follows in a Lambda environment.
 
   The `lambdaEnd: true` tells the Client to (a) mark the lambda as inactive so
   a subsequent intake request is not started until the next invocation, and
-  (b) signal the Elastic AWS Lambda Extension the this invocation is done.
+  (b) signal the Elastic AWS Lambda Extension that this invocation is done.
   The user's Lambda handler should not finish until `cb` is called. This
   ensures that the extension receives tracing data and the end signal before
   the Lambda Runtime freezes the VM.

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function Client (opts) {
 
   this._corkTimer = null
   this._agent = null
-  this._active = false
+  this._activeIntakeReq = false
   this._onflushed = null
   this._transport = null
   this._configTimer = null
@@ -526,8 +526,8 @@ Client.prototype._writeBatch = function (objs, cb) {
 }
 
 Client.prototype._writeFlush = function (cb) {
-  this._log.trace({ active: this._active }, '_writeFlush')
-  if (this._active) {
+  this._log.trace({ activeIntakeReq: this._activeIntakeReq }, '_writeFlush')
+  if (this._activeIntakeReq) {
     // In a Lambda environment a flush is almost certainly a signal that the
     // runtime environment is about to be frozen: tell the intake request
     // to finish up quickly.
@@ -783,8 +783,8 @@ function getChoppedStreamHandler (client, onerror) {
     const intakeResTimeout = client._conf.intakeResTimeout
     const intakeResTimeoutOnEnd = client._conf.intakeResTimeoutOnEnd
 
-    // `_active` is used to coordinate the callback to `client.flush(db)`.
-    client._active = true
+    // `_activeIntakeReq` is used to coordinate the callback to `client.flush(db)`.
+    client._activeIntakeReq = true
 
     // Handle conclusion of this intake request. Each "part" is expected to call
     // `completePart()` at least once -- multiple calls are okay for cases like
@@ -840,7 +840,7 @@ function getChoppedStreamHandler (client, onerror) {
       client._intakeRequestGracefulExitFn = null
 
       client.sent = client._numEventsEnqueued
-      client._active = false
+      client._activeIntakeReq = false
       const backoffDelayMs = client._getBackoffDelay(!!err)
       if (err) {
         log.trace({ timeline, bytesWritten, backoffDelayMs, err },

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const kFlush = Symbol('flush')
 const kLambdaEndFlush = Symbol('lambdaEndFlush')
 function isFlushMarker (obj) {
   return obj === kFlush || obj === kLambdaEndFlush
+}
 
 const hostname = os.hostname()
 const requiredOpts = [

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function Client (opts) {
   this._corkTimer = null
   this._agent = null
   this._activeIntakeReq = false
-  this._onflushed = null
+  this._onIntakeReqConcluded = null
   this._transport = null
   this._configTimer = null
   this._backoffReconnectCount = 0
@@ -534,7 +534,7 @@ Client.prototype._writeFlush = function (cb) {
     if (this._intakeRequestGracefulExitFn && isLambdaExecutionEnvironment) {
       this._intakeRequestGracefulExitFn()
     }
-    this._onflushed = cb
+    this._onIntakeReqConcluded = cb
     this._chopper.chop()
   } else {
     this._chopper.chop(cb)
@@ -850,9 +850,9 @@ function getChoppedStreamHandler (client, onerror) {
         log.trace({ timeline, bytesWritten, backoffDelayMs },
           'conclude intake request: success')
       }
-      if (client._onflushed) {
-        client._onflushed()
-        client._onflushed = null
+      if (client._onIntakeReqConcluded) {
+        client._onIntakeReqConcluded()
+        client._onIntakeReqConcluded = null
       }
 
       if (backoffDelayMs > 0) {

--- a/index.js
+++ b/index.js
@@ -544,23 +544,11 @@ Client.prototype._writeFlush = function (flushMarker, cb) {
 
   let onFlushed = cb
   if (isLambdaExecutionEnvironment && flushMarker === kLambdaEndFlush) {
-    // XXX For now the "micdrop" (the `?flushed=true` signal to the ext) is
-    //     disabled by default until there is an extension release after v0.0.3
-    //     with https://github.com/elastic/apm-aws-lambda/pull/132 which fixes
-    //     panics reported in https://github.com/elastic/apm-aws-lambda/issues/133
-    //     To enable: XXX_ELASTIC_APM_ENABLE_MICDROP=1
-    const micdropEnabled = process.env.XXX_ELASTIC_APM_ENABLE_MICDROP &&
-      process.env.XXX_ELASTIC_APM_ENABLE_MICDROP !== '0' &&
-      process.env.XXX_ELASTIC_APM_ENABLE_MICDROP !== 'false'
-    if (micdropEnabled) {
-      onFlushed = () => {
-        // Signal the Elastic AWS Lambda extension that it is done passing data
-        // for this invocation, then call `cb()` so the wrapped Lambda handler
-        // can finish.
-        this._signalLambdaEnd(cb)
-      }
-    } else {
-      console.log('XXX micdrop disabled, use XXX_ELASTIC_APM_ENABLE_MICDROP=1 to enable')
+    onFlushed = () => {
+      // Signal the Elastic AWS Lambda extension that it is done passing data
+      // for this invocation, then call `cb()` so the wrapped Lambda handler
+      // can finish.
+      this._signalLambdaEnd(cb)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -532,8 +532,7 @@ Client.prototype._writeBatch = function (objs, cb) {
 }
 
 Client.prototype._writeFlush = function (flushMarker, cb) {
-  this._log.trace({ activeIntakeReq: this._activeIntakeReq,
-    lambdaEnd: flushMarker === kLambdaEndFlush }, '_writeFlush')
+  this._log.trace({ activeIntakeReq: this._activeIntakeReq, lambdaEnd: flushMarker === kLambdaEndFlush }, '_writeFlush')
 
   let onFlushed = cb
   if (isLambdaExecutionEnvironment && flushMarker === kLambdaEndFlush) {
@@ -1122,7 +1121,6 @@ Client.prototype._signalLambdaEnd = function (cb) {
   const startTime = performance.now()
   const finish = errOrErrMsg => {
     const durationMs = performance.now() - startTime
-    let err = null
     if (errOrErrMsg) {
       this._log.error({ err: errOrErrMsg, durationMs }, 'error signaling lambda invocation done')
     } else {
@@ -1159,7 +1157,6 @@ Client.prototype._signalLambdaEnd = function (cb) {
   })
   req.end()
 }
-
 
 /**
  * Fetch the APM Server version and set `this._apmServerVersion`.

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -13,6 +13,7 @@ class NoopLogger {
   error () {}
   fatal () {}
   child () { return this }
+  isLevelEnabled (_level) { return false }
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
   "files": [
     "lib"
   ],
-  "// scripts.test": "quoting arg to tape to avoid too long argv, let tape do globbing",
   "scripts": {
-    "test": "standard && nyc tape \"test/*.test.js\""
+    "test": "standard && nyc ./test/run_tests.sh"
   },
   "engines": {
     "node": "^8.6.0 || 10 || >=12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "10.5.0",
+  "version": "11.0.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -221,11 +221,11 @@ test('client.flush(callback) - with active request', function (t) {
       res.end()
     })
   }).client({ bufferWindowTime: -1, apmServerVersion: '8.0.0' }, function (client) {
-    t.equal(client._active, false, 'no outgoing HTTP request to begin with')
+    t.equal(client._activeIntakeReq, false, 'no outgoing HTTP request to begin with')
     client.sendSpan({ foo: 42 })
-    t.equal(client._active, true, 'an outgoing HTTP request should be active')
+    t.equal(client._activeIntakeReq, true, 'an outgoing HTTP request should be active')
     client.flush(function () {
-      t.equal(client._active, false, 'the outgoing HTTP request should be done')
+      t.equal(client._activeIntakeReq, false, 'the outgoing HTTP request should be done')
       client.end()
       server.close()
       t.end()
@@ -256,9 +256,9 @@ test('client.flush(callback) - with queued request', function (t) {
     client.sendSpan({ req: 1 })
     client.flush()
     client.sendSpan({ req: 2 })
-    t.equal(client._active, true, 'an outgoing HTTP request should be active')
+    t.equal(client._activeIntakeReq, true, 'an outgoing HTTP request should be active')
     client.flush(function () {
-      t.equal(client._active, false, 'the outgoing HTTP request should be done')
+      t.equal(client._activeIntakeReq, false, 'the outgoing HTTP request should be done')
       client.end()
       server.close()
       t.end()

--- a/test/lambda-usage.test.js
+++ b/test/lambda-usage.test.js
@@ -1,0 +1,161 @@
+'use strict'
+
+// Test the expected usage of this Client in an AWS Lambda environment.
+// The "Notes on Lambda usage" section in the README.md describes the
+// expected usage.
+
+// Must set this before the Client is imported so it thinks it is in a Lambda env.
+process.env.AWS_LAMBDA_FUNCTION_NAME = 'myFn'
+
+const { URL } = require('url')
+const zlib = require('zlib')
+const test = require('tape')
+const { APMServer } = require('./lib/utils')
+
+test('lambda usage', suite => {
+  let server
+  let client
+  let reqsToServer = []
+  let lateSpanInSameTickCallbackCalled = false
+  let lateSpanInNextTickCallbackCalled = false
+
+  test('setup mock APM server', t => {
+    server = APMServer(function (req, res) {
+      // Capture intake req data to this mock APM server to `reqsToServer`.
+      const reqInfo = {
+        method: req.method,
+        path: req.url,
+        url: new URL(req.url, 'http://localhost'),
+        headers: req.headers,
+        events: []
+      }
+      let instream = req
+      if (req.headers['content-encoding'] === 'gzip') {
+        instream = req.pipe(zlib.createGunzip())
+      } else {
+        instream.setEncoding('utf8')
+      }
+      let body = ''
+      instream.on('data', chunk => {
+        body += chunk
+      })
+      instream.on('end', () => {
+        body
+          .split(/\n/g) // parse each line
+          .filter(line => line.trim()) // ... if it is non-empty
+          .forEach(line => {
+            reqInfo.events.push(JSON.parse(line)) // ... append to reqInfo.events
+          })
+        reqsToServer.push(reqInfo)
+        res.writeHead(202) // the expected response from intake API endpoint
+        res.end('{}')
+      })
+    })
+
+    server.client({
+      apmServerVersion: '8.0.0',
+      centralConfig: false
+    }, function (client_) {
+      client = client_
+      t.end()
+    })
+  })
+
+  test('clients stays corked before .lambdaStart()', t => {
+    // Add more events than `bufferWindowSize` and wait for more than
+    // `bufferWindowTime`, and the Client should *still* be corked.
+    const aTrans = { name: 'aTrans', type: 'custom', result: 'success' /* ... */ }
+    for (let i = 0; i < client._conf.bufferWindowSize + 1; i++) {
+      client.sendTransaction(aTrans)
+    }
+    setTimeout(() => {
+      t.equal(client._writableState.corked, 1,
+        'corked after bufferWindowSize events and bufferWindowTime')
+      t.equal(reqsToServer.length, 0, 'no intake request was made to APM Server')
+      t.end()
+    }, client._conf.bufferWindowTime + 10)
+  })
+
+  test('lambda invocation', t => {
+    client.lambdaStart() // 1. start of invocation
+    setTimeout(() => {
+      client.sendTransaction({ name: 'GET /aStage/myFn', type: 'lambda', result: 'success' /* ... */ })
+      client.sendSpan({ name: 'mySpan', type: 'custom', result: 'success' /* ... */ })
+
+      // 2. end of invocation
+      client.flush({ lambdaEnd: true }, function () {
+        t.ok(reqsToServer.length > 1, 'at least 2 intake requests to APM Server')
+        t.equal(reqsToServer[reqsToServer.length - 1].url.searchParams.get('flushed'), 'true',
+          'the last intake request had "?flushed=true" query param')
+
+        let allEvents = []
+        reqsToServer.forEach(r => { allEvents = allEvents.concat(r.events) })
+        t.equal(allEvents[allEvents.length - 2].transaction.name, 'GET /aStage/myFn',
+          'second last event is the lambda transaction')
+        t.equal(allEvents[allEvents.length - 1].span.name, 'mySpan',
+          'last event is the lambda span')
+
+        reqsToServer = [] // reset
+        t.end()
+      })
+
+      // Explicitly send late events and flush *after* the
+      // `client.flush({lambdaEnd:true})` -- both in the same tick and next
+      // ticks -- to test that these get buffered until the next lambda
+      // invocation.
+      client.sendSpan({ name: 'lateSpanInSameTick', type: 'custom' /* ... */ })
+      client.flush(function () {
+        lateSpanInSameTickCallbackCalled = true
+      })
+      setImmediate(() => {
+        client.sendSpan({ name: 'lateSpanInNextTick', type: 'custom' /* ... */ })
+        client.flush(function () {
+          lateSpanInNextTickCallbackCalled = true
+        })
+      })
+    }, 10)
+  })
+
+  // Give some time to make sure there isn't some unexpected short async
+  // interaction.
+  test('pause between lambda invocations', t => {
+    setTimeout(() => {
+      t.end()
+    }, 1000)
+  })
+
+  test('second lambda invocation', t => {
+    t.equal(lateSpanInSameTickCallbackCalled, false, 'lateSpanInSameTick flush callback not yet called')
+    t.equal(lateSpanInNextTickCallbackCalled, false, 'lateSpanInNextTick flush callback not yet called')
+    t.equal(reqsToServer.length, 0, 'no intake request was made to APM Server since last lambdaEnd')
+
+    client.lambdaStart()
+    setTimeout(() => {
+      client.flush({ lambdaEnd: true }, () => {
+        t.equal(reqsToServer.length, 3, '3 intake requests to APM Server')
+        t.equal(lateSpanInSameTickCallbackCalled, true, 'lateSpanInSameTick flush callback has now been called')
+        t.equal(lateSpanInNextTickCallbackCalled, true, 'lateSpanInNextTick flush callback has now been called')
+
+        t.equal(reqsToServer[0].events.length, 2,
+          'the first intake request has 2 events')
+        t.equal(reqsToServer[0].events[1].span.name, 'lateSpanInSameTick',
+          'of which the second event is the lateSpanInSameTick')
+        t.equal(reqsToServer[1].events.length, 2,
+          'the second intake request has 2 events')
+        t.equal(reqsToServer[1].events[1].span.name, 'lateSpanInNextTick',
+          'of which the second event is the lateSpanInNextTick')
+        t.equal(reqsToServer[reqsToServer.length - 1].url.searchParams.get('flushed'), 'true',
+          'the last intake request had "?flushed=true" query param')
+        t.end()
+      })
+    }, 10)
+  })
+
+  test('teardown', t => {
+    server.close()
+    client.destroy()
+    t.end()
+  })
+
+  suite.end()
+})

--- a/test/lambda-usage.test.js
+++ b/test/lambda-usage.test.js
@@ -3,6 +3,8 @@
 // Test the expected usage of this Client in an AWS Lambda environment.
 // The "Notes on Lambda usage" section in the README.md describes the
 // expected usage.
+//
+// Note: This test file needs to be run in its own process.
 
 // Must set this before the Client is imported so it thinks it is in a Lambda env.
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'myFn'

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run each test/*.test.js file in a separate process.
+#
+
+TOP=$(cd $(dirname $0)/../ >/dev/null; pwd)
+
+ls $TOP/test/*.test.js | while read f; do
+    echo ""
+    echo "# runnign 'node $f'"
+    node $f
+done


### PR DESCRIPTION
This adds 'Client#lambdaStart()' and the 'lambdaEnd: true' option to
'Client#flush([opts,] [cb])' to support for flushing Lambda invocation
tracing data and signaling the Elastic Lambda extension per spec.
https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-aws-lambda.md#data-flushing

Refs: https://github.com/elastic/apm-agent-nodejs/issues/2485


# Checklist

- [x] waiting for [extension panic fixes](https://github.com/elastic/apm-aws-lambda/pull/132) before enabling the '?flushed=true' signaling by default
- [x] tests of the new APIs

