### PR TITLE
fix: occasional "socket hang up" errors in APM server intake requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # elastic-apm-http-client changelog
 
+## Unreleased
+
+- Add the `freeSocketTimeout` option, with a default of 4000 (ms), and switch
+  from Node.js's core `http.Agent` to the [agentkeepalive package](https://github.com/node-modules/agentkeepalive)
+  to fix ECONNRESET issues with HTTP Keep-Alive usage talking to APM Server
+  (https://github.com/elastic/apm-agent-nodejs/issues/2594).
+
 ## v10.4.0
 
 - Add APM Server version checking to the client. On creation the client will

--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ HTTP client configuration:
   `Infinity`)
 - `maxFreeSockets` - Maximum number of sockets to leave open in a free
   state. Only relevant if `keepAlive` is set to `true` (default: `256`)
+- `freeSocketTimeout` - A number of milliseconds of inactivity on a free
+  (kept-alive) socket after which to timeout and recycle the socket. Set this to
+  a value less than the HTTP Keep-Alive timeout of the APM server to avoid
+  [ECONNRESET exceptions](https://medium.com/ssense-tech/reduce-networking-errors-in-nodejs-23b4eb9f2d83).
+  This defaults to 4000ms to be less than the [node.js HTTP server default of
+  5s](https://nodejs.org/api/http.html#serverkeepalivetimeout) (useful when
+  using a Node.js-based mock APM server) and the [Go lang Dialer `KeepAlive`
+  default of 15s](https://pkg.go.dev/net#Dialer) (when talking to the Elastic
+  APM Lambda extension). (default: `4000`)
 
 Cloud & Extra Metadata Configuration:
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "Thomas Watson <w@tson.dk> (https://twitter.com/wa7son)",
   "license": "MIT",
   "dependencies": {
+    "agentkeepalive": "^4.2.1",
     "breadth-filter": "^2.0.0",
     "container-info": "^1.0.1",
     "end-of-stream": "^1.4.4",


### PR DESCRIPTION
Use the 'agentkeepalive' alternative to Node.js core `http.Agent`
for keep-alive handling to get the `freeSocketTimeout` option that
can timeout kept-alive (aka "free") sockets before getting in the
range of the downstream APM Server (or Lambda extension) HTTP
Keep-Alive timeout. This avoids occasional ECONNRESET errors.

Fixes: #2594