### PR TITLE
fix: do not back-off on intake req errors in Lambda env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # elastic-apm-http-client changelog
 
+## Unreleased
+
+- Fix an issue when running in a Lambda function, where a missing or erroring
+  APM Lambda extension could result in apmclient back-off such that (a) the
+  end-of-lambda-invocation signaling (`?flushed=true`) would not happen and
+  (b) premature "beforeExit" event could result in the Lambda Runtime
+  responding `null` before the Lambda function could respond
+  (https://github.com/elastic/apm-agent-nodejs/issues/1831).
+
 ## v11.0.0
 
 - Add support for coordinating data flushing in an AWS Lambda environment. The


### PR DESCRIPTION
Doing the back-off in a Lambda env can result in the APM agent instrumentation *breaking* the Lambda function response: https://github.com/elastic/apm-agent-nodejs/issues/2598
See the inline comment and the motivation at: https://github.com/elastic/apm/pull/613


## commit message

```
fix: do not back-off on intake req errors in Lambda env

Refs: https://github.com/elastic/apm-agent-nodejs/issues/2598
Refs: https://github.com/elastic/apm/pull/613
```