### PR TITLE
fix: ensure run_tests.sh exits with non zero code when there's a test error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test-vers:
     strategy:
       matrix:
-        node: ['8.6', '8', '10', '12', '14', '15', '16']
+        node: ['8.6', '8', '10', '12', '14', '15', '16', '18']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -162,7 +162,7 @@ test('reject unauthorized TLS by default', function (t) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
       let expectedErrorMessage = 'self signed certificate'
-      if(semver.gte(process.version, 'v17.0.0')) {
+      if (semver.gte(process.version, 'v17.0.0')) {
         expectedErrorMessage = 'self-signed certificate'
       }
       t.equal(err.message, expectedErrorMessage)

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -161,7 +161,11 @@ test('reject unauthorized TLS by default', function (t) {
   }).client({ apmServerVersion: '8.0.0' }, function (client) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error)
-      t.equal(err.message, 'self signed certificate')
+      let expectedErrorMessage = 'self signed certificate'
+      if(semver.gte(process.version, 'v17.0.0')) {
+        expectedErrorMessage = 'self-signed certificate'
+      }
+      t.equal(err.message, expectedErrorMessage)
       t.equal(err.code, 'DEPTH_ZERO_SELF_SIGNED_CERT')
       server.close()
       t.end()

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,10 +3,15 @@
 # Run each test/*.test.js file in a separate process.
 #
 
+EXIT_CODE=0
 TOP=$(cd $(dirname $0)/../ >/dev/null; pwd)
-
-ls $TOP/test/*.test.js | while read f; do
+runTest() {
     echo ""
-    echo "# runnign 'node $f'"
-    node $f
+    echo "# runnign 'node $1'"
+    node $1 || EXIT_CODE=$?
+}
+
+for i in $TOP/test/*.test.js; do
+    runTest $i
 done
+exit $EXIT_CODE


### PR DESCRIPTION
The `run_tests.sh` bash script would always exit with a code of `0`, even if one of the test files had `not ok` tests.  This meant that the test failures were not picked up by CI.  

This PR changes that script to ensure we exit with a `0` if all test suites ran `ok`, or exit with the last failure code seen.

This PR also bumps the GitHub actions versions tested to include Node.js 18, and fixes a small test fixture issue with some changed output in Node 18.