### PR TITLE
fix: put [5s, 1d] range guard on the delay before re-fetching central config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # elastic-apm-http-client changelog
 
+## Unreleased
+
+- Add guards to ensure that a crazy `Cache-Control: max-age=...` response
+  header cannot accidentally result in inappropriate intervals for fetching
+  central config. The re-fetch delay is clamped to `[5 seconds, 1 day]`.
+  (https://github.com/elastic/apm-agent-nodejs/issues/2941)
+
 ## v11.0.1
 
 - Fix an issue when running in a Lambda function, where a missing or erroring

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const StreamChopper = require('stream-chopper')
 const ndjson = require('./lib/ndjson')
 const { NoopLogger } = require('./lib/logging')
 const truncate = require('./lib/truncate')
+const { getCentralConfigIntervalS } = require('./lib/central-config')
 
 module.exports = Client
 
@@ -432,16 +433,7 @@ Client.prototype._pollConfig = function () {
 Client.prototype._scheduleNextConfigPoll = function (seconds) {
   if (this._configTimer !== null) return
 
-  // Re-fetch central config after the given number of `seconds`.
-  // Default to 5 minutes, minimum 5s, max 1d.
-  //
-  // The maximum of 1d ensures we don't get surprised by an overflow value to
-  // `setTimeout` per https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
-  const DELAY_DEFAULT_S = 300 // 5 min
-  const DELAY_MIN_S = 5
-  const DELAY_MAX_S = 86400 // 1d
-  const delayS = Math.min(Math.max(seconds || DELAY_DEFAULT_S, DELAY_MIN_S), DELAY_MAX_S)
-
+  const delayS = getCentralConfigIntervalS(seconds)
   this._configTimer = setTimeout(() => {
     this._configTimer = null
     this._pollConfig()

--- a/lib/central-config.js
+++ b/lib/central-config.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Central config-related utilities for the APM http client.
+
+const INTERVAL_DEFAULT_S = 300 // 5 min
+const INTERVAL_MIN_S = 5
+const INTERVAL_MAX_S = 86400 // 1d
+
+/**
+ * Determine an appropriate delay until the next fetch of Central Config.
+ * Default to 5 minutes, minimum 5s, max 1d.
+ *
+ * The maximum of 1d ensures we don't get surprised by an overflow value to
+ * `setTimeout` per https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+ *
+ * @param {Number|undefined} seconds - A number of seconds, typically pulled
+ *    from a `Cache-Control: max-age=${seconds}` header on a previous central
+ *    config request.
+ * @returns {Number}
+ */
+function getCentralConfigIntervalS(seconds) {
+  if (typeof seconds !== 'number' || seconds <= 0) {
+    return INTERVAL_DEFAULT_S
+  }
+  return Math.min(Math.max(seconds, INTERVAL_MIN_S), INTERVAL_MAX_S)
+}
+
+module.exports = {
+  getCentralConfigIntervalS,
+
+  // These are exported for testing.
+  INTERVAL_DEFAULT_S,
+  INTERVAL_MIN_S,
+  INTERVAL_MAX_S
+}

--- a/lib/central-config.js
+++ b/lib/central-config.js
@@ -18,7 +18,7 @@ const INTERVAL_MAX_S = 86400 // 1d
  *    config request.
  * @returns {Number}
  */
-function getCentralConfigIntervalS(seconds) {
+function getCentralConfigIntervalS (seconds) {
   if (typeof seconds !== 'number' || seconds <= 0) {
     return INTERVAL_DEFAULT_S
   }

--- a/test/central-config.test.js
+++ b/test/central-config.test.js
@@ -3,7 +3,52 @@
 const test = require('tape')
 
 const { APMServer, validOpts, assertConfigReq } = require('./lib/utils')
+const {
+  getCentralConfigIntervalS,
+  INTERVAL_DEFAULT_S,
+  INTERVAL_MIN_S,
+  INTERVAL_MAX_S
+} = require('../lib/central-config')
 const Client = require('../')
+
+test('getCentralConfigIntervalS', function (t) {
+  const testCases = [
+    // [ <input arg>, <expected result> ]
+    [-4, INTERVAL_DEFAULT_S],
+    [-1, INTERVAL_DEFAULT_S],
+    [0, 300],
+    [1, INTERVAL_MIN_S],
+    [2, INTERVAL_MIN_S],
+    [3, INTERVAL_MIN_S],
+    [4, INTERVAL_MIN_S],
+    [5, INTERVAL_MIN_S],
+    [6, 6],
+    [7, 7],
+    [8, 8],
+    [9, 9],
+    [10, 10],
+    [86398, 86398],
+    [86399, 86399],
+    [86400, 86400],
+    [86401, INTERVAL_MAX_S],
+    [86402, INTERVAL_MAX_S],
+    [86403, INTERVAL_MAX_S],
+    [86404, INTERVAL_MAX_S],
+    [null, INTERVAL_DEFAULT_S],
+    [undefined, INTERVAL_DEFAULT_S],
+    [false, INTERVAL_DEFAULT_S],
+    [true, INTERVAL_DEFAULT_S],
+    ['a string', INTERVAL_DEFAULT_S],
+    [{}, INTERVAL_DEFAULT_S],
+    [[], INTERVAL_DEFAULT_S]
+  ]
+
+  testCases.forEach(testCase => {
+    t.equal(getCentralConfigIntervalS(testCase[0]), testCase[1],
+      `getCentralConfigIntervalS(${testCase[0]}) -> ${testCase[1]}`)
+  })
+  t.end()
+})
 
 test('central config disabled', function (t) {
   const origPollConfig = Client.prototype._pollConfig


### PR DESCRIPTION
Refs: https://github.com/elastic/apm-agent-nodejs/issues/2941

The [spec change](https://github.com/elastic/apm/pull/667/files) requires a minimum 5s delay for refetching central config. The Node.js APM agent didn't have the "spin loop fetching central config from `Cache-Control: max-age=0`" issue. However, theoretically a *large* max-age value could overflow the max `setTimeout` delay (https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value) which could result in a similar spin loop. I picked a maximum value of 1 day -- a large enough value that I cannot imagine it getting in a way of a legitimate max-age value from the APM server.

It might be worth adding a max guard to the spec.