### PR TITLE
fix: Prevent a possible tight loop in central config fetching.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # elastic-apm-http-client changelog
 
+## v11.0.3
+
+- Prevent a possible tight loop in central config fetching.
+  (https://github.com/elastic/apm-agent-nodejs/issues/3029)
+
 ## v11.0.2
+
+**Bad release. Upgrade to 11.0.3.**
 
 - Add guards to ensure that a crazy `Cache-Control: max-age=...` response
   header cannot accidentally result in inappropriate intervals for fetching

--- a/index.js
+++ b/index.js
@@ -1467,8 +1467,14 @@ function normalizeGlobalLabels (labels) {
 // https://httpwg.org/specs/rfc9111.html#cache-response-directive.max-age
 function getMaxAge (res) {
   const header = res.headers['cache-control']
-  const match = header && header.match(/max-age=(\d+)/i)
-  return parseInt(match && match[1], 10)
+  if (!header) {
+    return undefined
+  }
+  const match = header.match(/max-age=(\d+)/i)
+  if (!match) {
+    return undefined
+  }
+  return parseInt(match[1], 10)
 }
 
 // Wrap the given Error object, including the given message.

--- a/lib/central-config.js
+++ b/lib/central-config.js
@@ -19,7 +19,7 @@ const INTERVAL_MAX_S = 86400 // 1d
  * @returns {Number}
  */
 function getCentralConfigIntervalS (seconds) {
-  if (typeof seconds !== 'number' || seconds <= 0) {
+  if (typeof seconds !== 'number' || isNaN(seconds) || seconds <= 0) {
     return INTERVAL_DEFAULT_S
   }
   return Math.min(Math.max(seconds, INTERVAL_MIN_S), INTERVAL_MAX_S)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "11.0.2",
+  "version": "11.0.3",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/test/central-config.test.js
+++ b/test/central-config.test.js
@@ -34,6 +34,7 @@ test('getCentralConfigIntervalS', function (t) {
     [86402, INTERVAL_MAX_S],
     [86403, INTERVAL_MAX_S],
     [86404, INTERVAL_MAX_S],
+    [NaN, INTERVAL_DEFAULT_S],
     [null, INTERVAL_DEFAULT_S],
     [undefined, INTERVAL_DEFAULT_S],
     [false, INTERVAL_DEFAULT_S],


### PR DESCRIPTION
If a central config request does not receive a Cache-Control response
header with a `max-age` field, then it incorrectly results in `NaN` for
the interval for the next central config fetch.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/3029
