### PR TITLE
feat: add an 'agentActivationMethod' config var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v11.2.0
 
 - Support a new `agentActivationMethod` string config var that is added to
-  'metadata.service.agent.installation.method'. XXX spec link
+  'metadata.service.agent.installation.method'. Spec:
+  https://github.com/elastic/apm/blob/main/specs/agents/metadata.md#activation-method
 
 ## v11.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # elastic-apm-http-client changelog
 
+## v11.1.0
+
+- Support a new `agentInstallationMethod` string config var that is added to
+  'metadata.service.agent.installation.method'. XXX spec link
+
 ## v11.0.3
 
 - Prevent a possible tight loop in central config fetching.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v11.2.0
 
-- Support a new `agentInstallationMethod` string config var that is added to
+- Support a new `agentActivationMethod` string config var that is added to
   'metadata.service.agent.installation.method'. XXX spec link
 
 ## v11.1.0
@@ -19,7 +19,6 @@
   "localhost" to avoid ambiguity if localhost resolves to multiple addresses
   (e.g. IPv4 and IPv6). APM server only listens on IPv4 by default.
   (https://github.com/elastic/apm-agent-nodejs/pull/3049)
->>>>>>> main
 
 ## v11.0.3
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Data sent to the APM Server as part of the [metadata object](https://www.elastic
 
 - `agentName` - (required) The APM agent name
 - `agentVersion` - (required) The APM agent version
+- `agentInstallationMethod` - An enum string (XXX spec) that identifies the way this agent was installed/started
 - `serviceName` - (required) The name of the service being instrumented
 - `serviceNodeName` - Unique name of the service being instrumented
 - `serviceVersion` - The version of the service being instrumented

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See also the "Cloud & Extra Metadata" section below.
 
 - `agentName` - (required) The APM agent name
 - `agentVersion` - (required) The APM agent version
-- `agentInstallationMethod` - An enum string (XXX spec) that identifies the way this agent was installed/started
+- `agentActivationMethod` - An enum string ([spec](https://github.com/elastic/apm/blob/main/specs/agents/metadata.md#activation-method)) that identifies the way this agent was activated/started
 - `serviceName` - (required) The name of the service being instrumented
 - `serviceNodeName` - Unique name of the service being instrumented
 - `serviceVersion` - The version of the service being instrumented

--- a/index.js
+++ b/index.js
@@ -1381,10 +1381,8 @@ function getMetadata (opts) {
     labels: opts.globalLabels
   }
 
-  if (opts.agentInstallationMethod) {
-    payload.service.agent.installation = {
-      method: opts.agentInstallationMethod
-    }
+  if (opts.agentActivationMethod) {
+    payload.service.agent.activation_method = opts.agentActivationMethod
   }
 
   if (opts.serviceNodeName) {

--- a/index.js
+++ b/index.js
@@ -1374,6 +1374,12 @@ function getMetadata (opts) {
     labels: opts.globalLabels
   }
 
+  if (opts.agentInstallationMethod) {
+    payload.service.agent.installation = {
+      method: opts.agentInstallationMethod
+    }
+  }
+
   if (opts.serviceNodeName) {
     payload.service.node = {
       configured_name: opts.serviceNodeName

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "11.0.3",
+  "version": "11.1.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -214,6 +214,7 @@ test('metadata', function (t) {
   const opts = {
     agentName: 'custom-agentName',
     agentVersion: 'custom-agentVersion',
+    agentInstallationMethod: 'custom-agentInstallationMethod',
     serviceName: 'custom-serviceName',
     serviceNodeName: 'custom-serviceNodeName',
     serviceVersion: 'custom-serviceVersion',
@@ -246,7 +247,10 @@ test('metadata', function (t) {
             },
             agent: {
               name: 'custom-agentName',
-              version: 'custom-agentVersion'
+              version: 'custom-agentVersion',
+              installation: {
+                method: 'custom-agentInstallationMethod'
+              }
             },
             framework: {
               name: 'custom-frameworkName',

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -214,7 +214,7 @@ test('metadata', function (t) {
   const opts = {
     agentName: 'custom-agentName',
     agentVersion: 'custom-agentVersion',
-    agentInstallationMethod: 'custom-agentInstallationMethod',
+    agentActivationMethod: 'custom-agentActivationMethod',
     serviceName: 'custom-serviceName',
     serviceNodeName: 'custom-serviceNodeName',
     serviceVersion: 'custom-serviceVersion',
@@ -248,9 +248,7 @@ test('metadata', function (t) {
             agent: {
               name: 'custom-agentName',
               version: 'custom-agentVersion',
-              installation: {
-                method: 'custom-agentInstallationMethod'
-              }
+              activation_method: 'custom-agentActivationMethod'
             },
             framework: {
               name: 'custom-frameworkName',


### PR DESCRIPTION
This adds 'metadata.service.agent.activation_method' if the optional
config var is provided. Bump to v11.2.0.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/3039
