### PR TITLE
fix: change default APM server_url to 'http://127.0.0.1:8200' to avoid IPv6 ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # elastic-apm-http-client changelog
 
+## v11.0.4
+
+- Update the default `serverUrl` to "http://127.0.0.1:8200". We no longer use
+  "localhost" to avoid ambiguity if localhost resolves to multiple addresses
+  (e.g. IPv4 and IPv6). APM server only listens on IPv4 by default.
+  (https://github.com/elastic/apm-agent-nodejs/pull/3049)
+
 ## v11.0.3
 
 - Prevent a possible tight loop in central config fetching.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ HTTP client configuration:
   identify itself as
 - `secretToken` - The Elastic APM intake API secret token
 - `apiKey` - Elastic APM API key
-- `serverUrl` - The APM Server URL (default: `http://localhost:8200`)
+- `serverUrl` - The APM Server URL (default: `http://127.0.0.1:8200`)
 - `headers` - An object containing extra HTTP headers that should be
   used when making HTTP requests to he APM Server
 - `rejectUnauthorized` - Set to `false` if the client shouldn't verify

--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ Client.prototype.config = function (opts) {
   if (!this._conf.size && this._conf.size !== 0) this._conf.size = 750 * 1024
   if (!this._conf.time && this._conf.time !== 0) this._conf.time = 10000
   if (!this._conf.serverTimeout && this._conf.serverTimeout !== 0) this._conf.serverTimeout = 15000
-  if (!this._conf.serverUrl) this._conf.serverUrl = 'http://localhost:8200'
+  if (!this._conf.serverUrl) this._conf.serverUrl = 'http://127.0.0.1:8200'
   if (!this._conf.hostname) this._conf.hostname = hostname
   if (!this._conf.environment) this._conf.environment = process.env.NODE_ENV || 'development'
   if (!this._conf.truncateKeywordsAt) this._conf.truncateKeywordsAt = 1024
@@ -987,7 +987,7 @@ function getChoppedStreamHandler (client, onerror) {
       //
       // The HTTP keep-alive agent will unref sockets when unused, and ref them
       // during a request. Given that the normal makeIntakeRequest behaviour
-      // is to keep a request open for up to 10s (`apiRequestTimeout`), we must
+      // is to keep a request open for up to 10s (`apiRequestTime`), we must
       // manually unref the socket.
       //
       // The exception is when in a Lambda environment, where we *do* want to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
The APM agent won't *require* this change, because in the referenced
change it will be adding the same default on its end.

Refs: https://github.com/elastic/apm-agent-nodejs/pull/3049


# Checklist

- [x] Wait for the APM spec PR to get some feedback: https://github.com/elastic/apm/pull/727
