### PR TITLE
chore: add 'make cutarelease' and other dev conveniences

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
-# Test with all supported node versions.
-name: Test
+# Lint this change with the latest node LTS.
+name: Lint
 
 # https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/2
 on:
@@ -15,15 +15,12 @@ on:
     - '*.md'
 
 jobs:
-  test-vers:
-    strategy:
-      matrix:
-        node: ['8.6', '8', '10', '12', '14', '15', '16', '18', '19']
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node }}
+        node-version: '18'
     - run: npm install
-    - run: npm test
+    - run: npm run lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+# Some targets depend on https://github/trentm/json being on the PATH.
+JSON ?= json
+
+.PHONY: all
+all:
+	npm install
+
+.PHONY: test
+test:
+	npm test
+
+.PHONY: lint
+lint:
+	npm run lint
+
+# Ensure CHANGELOG.md and package.json have the same version for a release.
+.PHONY: check-version
+check-version:
+	@echo version is: $(shell cat package.json | json version)
+	[[ v`cat package.json | $(JSON) version` == `grep '^## ' CHANGELOG.md | head -1 | tail -1 | awk '{print $$2}'` ]]
+
+.PHONY: check
+check: lint check-version
+
+# Tag and release a new release based on the current package.json#version.
+# This long bit of Makefile does the following:
+# - ensure the repo isn't dirty (changed files)
+# - warn if we have a tag for this release already
+# - interactively confirm
+# - git tag
+# - npm publish
+.PHONY: cutarelease
+cutarelease: check
+	[[ `basename $(shell git symbolic-ref HEAD)` == 'main' ]]  # Can only release from 'main' branch.
+	[[ -z `git status --short` ]]  # If this fails, the working dir is dirty.
+	@which $(JSON) 2>/dev/null 1>/dev/null && \
+	    ver=$(shell $(JSON) -f package.json version) && \
+	    name=$(shell $(JSON) -f package.json name) && \
+	    publishedVer=$(shell npm view -j $(shell $(JSON) -f package.json name)@$(shell $(JSON) -f package.json version) version 2>/dev/null) && \
+	    if [[ -n "$$publishedVer" ]]; then \
+		echo "error: $$name@$$ver is already published to npm"; \
+		exit 1; \
+	    fi && \
+	    echo "** Are you sure you want to tag and publish $$name@$$ver to npm?" && \
+	    echo "** Enter to continue, Ctrl+C to abort." && \
+	    read
+	ver=$(shell cat package.json | $(JSON) version) && \
+	    date=$(shell date -u "+%Y-%m-%d") && \
+	    git tag -a "v$$ver" -m "version $$ver ($$date)" && \
+	    git push origin "v$$ver" && \
+	    npm publish

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "test": "standard && nyc ./test/run_tests.sh"
+    "lint": "standard",
+    "test": "nyc ./test/run_tests.sh"
   },
   "engines": {
     "node": "^8.6.0 || 10 || >=12"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -7,7 +7,7 @@ EXIT_CODE=0
 TOP=$(cd $(dirname $0)/../ >/dev/null; pwd)
 runTest() {
     echo ""
-    echo "# runnign 'node $1'"
+    echo "# running 'node $1'"
     node $1 || EXIT_CODE=$?
 }
 


### PR DESCRIPTION
Separate 'lint' and 'test'. Add testing of node v19.
