### PR TITLE
v11.3.0; send activation_method metadata only to APM server v8.7.1 or later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # elastic-apm-http-client changelog
 
+## v11.3.0
+
+- Ensure `metadata.service.agent.activation_method` is only sent for APM
+  server version 8.7.1 or later. APM server 8.7.0 included a bug where
+  receiving `activation_method` is harmful.
+  (https://github.com/elastic/apm-agent-nodejs/issues/3230)
+
+  This change adds the `client.supportsActivationMethodField()` method.
+
 ## v11.2.0
 
 - Support a new `agentActivationMethod` string config var that is added to

--- a/README.md
+++ b/README.md
@@ -306,6 +306,14 @@ This defaults to `true` if the remote APM server version is not known -- either
 because the background fetch of the APM Server version hasn't yet completed,
 or the version could not be fetched.
 
+### `client.supportsActivationMethodField()`
+
+This method returns a boolean indicating whether the remote APM Server (per
+the configured `serverUrl`) is of a version that supports the
+`metadata.service.agent.activation_method` field.
+
+This defaults to `false` if the remote APM server version is not known.
+
 ### `client.addMetadataFilter(fn)`
 
 Add a filter function for the ["metadata" object](https://www.elastic.co/guide/en/apm/server/current/metadata-api.html)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "11.2.0",
+  "version": "11.3.0",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/test/apm-server-version.test.js
+++ b/test/apm-server-version.test.js
@@ -212,7 +212,6 @@ test('APM server version fetch works for "8.7.1"', function (t) {
   })
 })
 
-
 test('APM server version is null on fetch error', function (t) {
   const HOPEFULLY_UNUSED_PORT_HACK = 62345
   const client = new Client(validOpts({

--- a/test/apm-server-version.test.js
+++ b/test/apm-server-version.test.js
@@ -42,6 +42,8 @@ test('APM server version fetch works for "6.6.0"', function (t) {
       'client._apmServerVersion is undefined immediately after client creation')
     t.equal(client.supportsKeepingUnsampledTransaction(), true,
       'client.supportsKeepingUnsampledTransaction() defaults to true before fetch')
+    t.equal(client.supportsActivationMethodField(), false,
+      'client.supportsActivationMethodField() defaults to false before fetch')
 
     // Currently there isn't a mechanism to wait for the fetch request, so for
     // now just wait a bit.
@@ -50,6 +52,8 @@ test('APM server version fetch works for "6.6.0"', function (t) {
       t.equal(client._apmServerVersion.toString(), '6.6.0')
       t.equal(client.supportsKeepingUnsampledTransaction(), true,
         'client.supportsKeepingUnsampledTransaction() is true after fetch')
+      t.equal(client.supportsActivationMethodField(), false,
+        'client.supportsActivationMethodField() is false after fetch')
 
       server.close()
       client.destroy()
@@ -123,6 +127,91 @@ test('APM server version fetch works for "8.0.0"', function (t) {
     }, 200)
   })
 })
+
+/**
+ * APM server 8.7.0 included a bug where APM agents sending `activation_method`
+ * was harmful. This test ensures we don't send that field to v8.7.0.
+ *
+ * See https://github.com/elastic/apm/pull/780
+ */
+test('APM server version fetch works for "8.7.0"', function (t) {
+  const server = APMServer(function (req, res) {
+    res.writeHead(200)
+    const verInfo = {
+      build_date: '2023-03-30T22:17:50Z',
+      build_sha: 'a183f675ecd03fca4a897cbe85fda3511bc3ca43',
+      version: '8.7.0'
+    }
+    res.end(JSON.stringify(verInfo, null, 2))
+  }).client({
+    agentActivationMethod: 'env-attach'
+  }, function (client) {
+    t.strictEqual(client._apmServerVersion, undefined,
+      'client._apmServerVersion is undefined immediately after client creation')
+    t.equal(client._conf.agentActivationMethod, 'env-attach', '_conf.agentActivationMethod')
+    t.equal(client.supportsActivationMethodField(), false,
+      'client.supportsActivationMethodField() defaults to false before fetch')
+    t.equal(JSON.parse(client._encodedMetadata).metadata.service.agent.activation_method, undefined,
+      'metadata does not include "activation_method" before fetch')
+
+    // Currently there isn't a mechanism to wait for the fetch request, so for
+    // now just wait a bit.
+    setTimeout(() => {
+      t.ok(client._apmServerVersion, 'client._apmServerVersion is set')
+      t.equal(client._apmServerVersion.toString(), '8.7.0')
+      t.equal(client.supportsActivationMethodField(), false,
+        'client.supportsActivationMethodField() is false after fetch')
+      t.equal(JSON.parse(client._encodedMetadata).metadata.service.agent.activation_method, undefined,
+        'metadata does not include "activation_method" after fetch')
+
+      server.close()
+      client.destroy()
+      t.end()
+    }, 200)
+  })
+})
+
+/**
+ * Starting with APM server 8.7.1, `activation_method` should be sent.
+ * See https://github.com/elastic/apm/pull/780
+ */
+test('APM server version fetch works for "8.7.1"', function (t) {
+  const server = APMServer(function (req, res) {
+    res.writeHead(200)
+    const verInfo = {
+      build_date: '2023-03-30T22:17:50Z',
+      build_sha: 'a183f675ecd03fca4a897cbe85fda3511bc3ca43',
+      version: '8.7.1'
+    }
+    res.end(JSON.stringify(verInfo, null, 2))
+  }).client({
+    agentActivationMethod: 'env-attach'
+  }, function (client) {
+    t.strictEqual(client._apmServerVersion, undefined,
+      'client._apmServerVersion is undefined immediately after client creation')
+    t.equal(client._conf.agentActivationMethod, 'env-attach', '_conf.agentActivationMethod')
+    t.equal(client.supportsActivationMethodField(), false,
+      'client.supportsActivationMethodField() defaults to false before fetch')
+    t.equal(JSON.parse(client._encodedMetadata).metadata.service.agent.activation_method, undefined,
+      'metadata does not include "activation_method" before fetch')
+
+    // Currently there isn't a mechanism to wait for the fetch request, so for
+    // now just wait a bit.
+    setTimeout(() => {
+      t.ok(client._apmServerVersion, 'client._apmServerVersion is set')
+      t.equal(client._apmServerVersion.toString(), '8.7.1')
+      t.equal(client.supportsActivationMethodField(), true,
+        'client.supportsActivationMethodField() is true after fetch')
+      t.equal(JSON.parse(client._encodedMetadata).metadata.service.agent.activation_method, 'env-attach',
+        'metadata includes "activation_method" after fetch')
+
+      server.close()
+      client.destroy()
+      t.end()
+    }, 200)
+  })
+})
+
 
 test('APM server version is null on fetch error', function (t) {
   const HOPEFULLY_UNUSED_PORT_HACK = 62345

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -228,7 +228,7 @@ test('metadata', function (t) {
         nope: 'this should be [object Object]'
       }
     },
-    apmServerVersion: '8.0.0' // avoid the APM server version fetch request
+    apmServerVersion: '8.7.1' // avoid the APM server version fetch request
   }
   const server = APMServer(function (req, res) {
     req = processIntakeReq(req)


### PR DESCRIPTION
Refs: https://github.com/elastic/apm-agent-nodejs/issues/3230
Refs: https://github.com/elastic/apm/pull/780
