### PR TITLE
v11.3.1; default to sending `activation_method` field if APM server version is not (yet) known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # elastic-apm-http-client changelog
 
+## v11.3.1
+
+- Tweak logic to only exclude `metadata.service.agent.activation_method` when
+  the APM server version is known to be 8.7.0 -- i.e. optimistically assume
+  it is a version that is fine. The APM server 8.7.0 issue isn't so severe that
+  we want a fast first serverless function invocation to not send the field.
+  (https://github.com/elastic/apm/pull/783)
+
 ## v11.3.0
 
 - Ensure `metadata.service.agent.activation_method` is only sent for APM

--- a/README.md
+++ b/README.md
@@ -310,9 +310,9 @@ or the version could not be fetched.
 
 This method returns a boolean indicating whether the remote APM Server (per
 the configured `serverUrl`) is of a version that supports the
-`metadata.service.agent.activation_method` field.
-
-This defaults to `false` if the remote APM server version is not known.
+`metadata.service.agent.activation_method` field. This is true for APM server
+versions >=8.7.1. It defaults to true if the APM server version is not (yet)
+known.
 
 ### `client.addMetadataFilter(fn)`
 

--- a/index.js
+++ b/index.js
@@ -1138,10 +1138,10 @@ Client.prototype.supportsKeepingUnsampledTransaction = function () {
   }
 }
 Client.prototype.supportsActivationMethodField = function () {
-  // APM server 8.7.0 had a bug where sending `activation_method` is *harmful*,
-  // therefore, if we don't *know* we are >=8.7.1, then assume no.
+  // APM server 8.7.0 had a bug where continuing to send `activation_method` is
+  // harmful.
   if (!this._apmServerVersion) {
-    return false
+    return true // Optimistically assume APM server isn't v8.7.0.
   } else {
     return semver.gte(this._apmServerVersion, '8.7.1')
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-http-client",
-  "version": "11.3.0",
+  "version": "11.3.1",
   "description": "A low-level HTTP client for communicating with the Elastic APM intake API",
   "main": "index.js",
   "directories": {

--- a/test/apm-server-version.test.js
+++ b/test/apm-server-version.test.js
@@ -151,7 +151,7 @@ test('APM server version fetch works for "8.7.0"', function (t) {
     t.equal(client._conf.agentActivationMethod, 'env-attach', '_conf.agentActivationMethod')
     t.equal(client.supportsActivationMethodField(), true,
       'client.supportsActivationMethodField() defaults to true before fetch')
-    t.ok("activation_method" in JSON.parse(client._encodedMetadata).metadata.service.agent,
+    t.ok('activation_method' in JSON.parse(client._encodedMetadata).metadata.service.agent,
       'metadata includes "activation_method" before fetch')
 
     // Currently there isn't a mechanism to wait for the fetch request, so for
@@ -192,7 +192,7 @@ test('APM server version fetch works for "8.7.1"', function (t) {
     t.equal(client._conf.agentActivationMethod, 'env-attach', '_conf.agentActivationMethod')
     t.equal(client.supportsActivationMethodField(), true,
       'client.supportsActivationMethodField() defaults to true before fetch')
-    t.ok("activation_method" in JSON.parse(client._encodedMetadata).metadata.service.agent,
+    t.ok('activation_method' in JSON.parse(client._encodedMetadata).metadata.service.agent,
       'metadata includes "activation_method" before fetch')
 
     // Currently there isn't a mechanism to wait for the fetch request, so for

--- a/test/apm-server-version.test.js
+++ b/test/apm-server-version.test.js
@@ -42,8 +42,8 @@ test('APM server version fetch works for "6.6.0"', function (t) {
       'client._apmServerVersion is undefined immediately after client creation')
     t.equal(client.supportsKeepingUnsampledTransaction(), true,
       'client.supportsKeepingUnsampledTransaction() defaults to true before fetch')
-    t.equal(client.supportsActivationMethodField(), false,
-      'client.supportsActivationMethodField() defaults to false before fetch')
+    t.equal(client.supportsActivationMethodField(), true,
+      'client.supportsActivationMethodField() defaults to true before fetch')
 
     // Currently there isn't a mechanism to wait for the fetch request, so for
     // now just wait a bit.
@@ -149,10 +149,10 @@ test('APM server version fetch works for "8.7.0"', function (t) {
     t.strictEqual(client._apmServerVersion, undefined,
       'client._apmServerVersion is undefined immediately after client creation')
     t.equal(client._conf.agentActivationMethod, 'env-attach', '_conf.agentActivationMethod')
-    t.equal(client.supportsActivationMethodField(), false,
-      'client.supportsActivationMethodField() defaults to false before fetch')
-    t.equal(JSON.parse(client._encodedMetadata).metadata.service.agent.activation_method, undefined,
-      'metadata does not include "activation_method" before fetch')
+    t.equal(client.supportsActivationMethodField(), true,
+      'client.supportsActivationMethodField() defaults to true before fetch')
+    t.ok("activation_method" in JSON.parse(client._encodedMetadata).metadata.service.agent,
+      'metadata includes "activation_method" before fetch')
 
     // Currently there isn't a mechanism to wait for the fetch request, so for
     // now just wait a bit.
@@ -190,10 +190,10 @@ test('APM server version fetch works for "8.7.1"', function (t) {
     t.strictEqual(client._apmServerVersion, undefined,
       'client._apmServerVersion is undefined immediately after client creation')
     t.equal(client._conf.agentActivationMethod, 'env-attach', '_conf.agentActivationMethod')
-    t.equal(client.supportsActivationMethodField(), false,
-      'client.supportsActivationMethodField() defaults to false before fetch')
-    t.equal(JSON.parse(client._encodedMetadata).metadata.service.agent.activation_method, undefined,
-      'metadata does not include "activation_method" before fetch')
+    t.equal(client.supportsActivationMethodField(), true,
+      'client.supportsActivationMethodField() defaults to true before fetch')
+    t.ok("activation_method" in JSON.parse(client._encodedMetadata).metadata.service.agent,
+      'metadata includes "activation_method" before fetch')
 
     // Currently there isn't a mechanism to wait for the fetch request, so for
     // now just wait a bit.


### PR DESCRIPTION
Optimistically assume the APM server version is not v8.7.0. This allows
typically avoiding the v8.7.0 bug (which isn't that severe) with still
sending the `activation_method` for intake requests before the APM
server version fetch completes -- e.g. for fast first serverless
invocations.

Refs: https://github.com/elastic/apm/issues/781
