### PR TITLE
chore: switch standard to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,10 +22,6 @@
   "ignorePatterns": [
     "/*.example.js", // a pattern for uncommited local dev files to avoid linting
     "/*.example.mjs", // a pattern for uncommited local dev files to avoid linting
-    "/.nyc_output",
-    "/build",
-    "node_modules",
-    "/test_output",
-    "tmp"
+    "/.nyc_output"
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,31 @@
+{
+  "root": true,
+  "env": {
+    "node": true
+  },
+  "extends": "standard",
+  "plugins": [
+    "license-header"
+  ],
+  "rules": {
+    "license-header/header": ["error", "./scripts/license-header.js"],
+    // Regarding "no-var": The opinion of this repository's maintainers is that
+    // while const/let are useful, the use of `var` is not bad and therefore
+    // does not need to be ruled out. Eliminating the use of `var` would be a
+    // large diff that (a) could theoretically cause bugs due to lexical scoping
+    // changes and (b) could theoretically impact perf (e.g. see
+    // https://github.com/microsoft/TypeScript/issues/52924). New code MAY
+    // prefer const/let over `var`. Code in "examples/" MUST use const/let --
+    // this is enforced by "examples/.eslintrc.json".
+    "no-var": "off"
+  },
+  "ignorePatterns": [
+    "/*.example.js", // a pattern for uncommited local dev files to avoid linting
+    "/*.example.mjs", // a pattern for uncommited local dev files to avoid linting
+    "/.nyc_output",
+    "/build",
+    "node_modules",
+    "/test_output",
+    "tmp"
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const assert = require('assert')
@@ -555,8 +561,8 @@ Client.prototype._writeBatch = function (objs, cb) {
     this._slowWriteBatch.numOver10Ms++
   }
   this._log.trace({
-    encodeTimeMs: encodeTimeMs,
-    fullTimeMs: fullTimeMs,
+    encodeTimeMs,
+    fullTimeMs,
     numEvents: objs.length,
     numBytes: chunk.length
   }, '_writeBatch')
@@ -1188,7 +1194,8 @@ function getChoppedStreamHandler (client, onerror) {
       log.trace('gzipStream "finish"')
       if (!completedFromPart.intakeReq && !completedFromPart.intakeRes) {
         const timeout = (client._writableState.ending || intakeRequestGracefulExitCalled
-          ? intakeResTimeoutOnEnd : intakeResTimeout)
+          ? intakeResTimeoutOnEnd
+          : intakeResTimeout)
         log.trace({ timeout }, 'start intakeResTimer')
         intakeResTimer = setTimeout(() => {
           completePart('intakeRes',
@@ -1450,7 +1457,7 @@ function getConfigRequestOptions (opts, agent) {
 
 function getBasicRequestOptions (method, defaultPath, headers, opts, agent) {
   return {
-    agent: agent,
+    agent,
     rejectUnauthorized: opts.rejectUnauthorized !== false,
     ca: opts.serverCaCert,
     hostname: opts.serverUrl.hostname,

--- a/lib/central-config.js
+++ b/lib/central-config.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Central config-related utilities for the APM http client.

--- a/lib/container-info.js
+++ b/lib/container-info.js
@@ -1,7 +1,9 @@
 /*
- * Copyright (c) 2018 Stephen Belanger
  * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
  */
+
 'use strict'
 
 const fs = require('fs')

--- a/lib/detect-hostname.js
+++ b/lib/detect-hostname.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Detect the current hostname, preferring the FQDN if possible.

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Logging utilities for the APM http client.

--- a/lib/ndjson.js
+++ b/lib/ndjson.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const stringify = require('fast-safe-stringify')

--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 var breadthFilter = require('breadth-filter')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "lint": "standard",
+    "lint": "eslint --ext=js,mjs,cjs . # requires node >=16.0.0",
+    "lint:fix": "eslint --ext=js,mjs,cjs --fix .  # requires node >=16.0.0",
     "test": "nyc node ./scripts/run-tests.js"
   },
   "engines": {
@@ -30,10 +31,15 @@
     "stream-chopper": "^3.0.1"
   },
   "devDependencies": {
+    "eslint": "^8.42.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-license-header": "^0.6.0",
+    "eslint-plugin-n": "^16.0.1",
+    "eslint-plugin-promise": "^6.1.1",
     "glob": "^7.2.3",
     "ndjson": "^1.5.0",
     "nyc": "^14.1.1",
-    "standard": "^14.3.1",
     "tape": "^4.11.0"
   },
   "repository": {

--- a/scripts/license-header.js
+++ b/scripts/license-header.js
@@ -1,0 +1,5 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */

--- a/test/abort.test.js
+++ b/test/abort.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')

--- a/test/apm-server-version.test.js
+++ b/test/apm-server-version.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Test that fetching the APM Server version works as expected.

--- a/test/backoff-delay.test.js
+++ b/test/backoff-delay.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Test Client.prototype._getBackoffDelay.

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')

--- a/test/central-config.test.js
+++ b/test/central-config.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const fs = require('fs')

--- a/test/container-info.test.js
+++ b/test/container-info.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const fs = require('fs')

--- a/test/edge-cases.test.js
+++ b/test/edge-cases.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const { exec } = require('child_process')

--- a/test/expectExtraMetadata.test.js
+++ b/test/expectExtraMetadata.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Test usage of `expectExtraMetadata: true` and `setExtraMetadata()`.

--- a/test/extraMetadata.test.js
+++ b/test/extraMetadata.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Test usage of `extraMetadata: ...`.

--- a/test/fixtures/cgroup_result.js
+++ b/test/fixtures/cgroup_result.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 module.exports = {

--- a/test/k8s.test.js
+++ b/test/k8s.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')

--- a/test/lambda-usage.test.js
+++ b/test/lambda-usage.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // Test the expected usage of this Client in an AWS Lambda environment.

--- a/test/lib/call-me-back-maybe.js
+++ b/test/lib/call-me-back-maybe.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 // A script, used by test/side-effects.js, to test that the client.flush
 // callback is called.
 //
@@ -17,7 +23,7 @@ const serverUrl = process.argv[2]
 
 const client = new Client({
   // logger: require('pino')({ level: 'trace', ...require('@elastic/ecs-pino-format')() }, process.stderr), // uncomment for debugging
-  serverUrl: serverUrl,
+  serverUrl,
   serviceName: 'call-me-back-maybe',
   agentName: 'my-nodejs-agent',
   agentVersion: '1.2.3',

--- a/test/lib/unref-client.js
+++ b/test/lib/unref-client.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 // This is used in test/side-effects.js to ensure that a Client with a

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const http = require('http')

--- a/test/metadata-filter.test.js
+++ b/test/metadata-filter.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')

--- a/test/side-effects.test.js
+++ b/test/side-effects.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const path = require('path')

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')

--- a/test/truncate.test.js
+++ b/test/truncate.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')

--- a/test/writev.test.js
+++ b/test/writev.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
 'use strict'
 
 const test = require('tape')


### PR DESCRIPTION
This PR mimics the lint configuration setup in https://github.com/elastic/apm-agent-nodejs and applies the changes required by eslint. By doing this the migration of the code inside the nodejs agent will be smoother.

This is a prep task to complete the migration of the code to the `apm-nodej-agent` repo mentioned in https://github.com/elastic/apm-agent-nodejs/issues/3506
